### PR TITLE
Test Hermes on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
       - *save-cache-detox-yarn
       - run:
           name: Enable Hermes
-          command: sed -i "s/enableHermes:\sfalse/enableHermes:\strue/g" android/app/build.gradle
+          command: sed -i "s/enableHermes:\sfalse/enableHermes:\ true/g" android/app/build.gradle
       - run:
           name: Build APK
           command: cd android && ./gradlew assembleRelease

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ jobs:
       - *restore-android-build-cache
       - run:
           name: Enable Hermes
-          command: sed -i "s/enableHermes: false/enableHermes: true/g" android/app/build.gradle
+          command: sed -i "s/enableHermes:\sfalse/enableHermes:\strue/g" android/app/build.gradle
       - run:
           name: Build APK
           command: cd android && ./gradlew assembleRelease

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ aliases:
       name: Restore Yarn Package Cache
       keys:
         - v1-yarn-packages-{{ checksum "yarn.lock" }}
-  - &save-cache-detox-pods
+  - &save-cache-detox
     save_cache:
       key: v1-detox-{{ checksum "yarn.lock"}}
       paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ ios: &ios
 android: &android
   working_directory: ~/react-native-url-polyfill/detox
   docker:
-    - image: circleci/android:api-29-node
+    - image: circleci/android:api-28-node
   environment:
     JAVA_TOOL_OPTIONS: '-Xmx1536m'
     GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,22 +1,26 @@
 aliases:
   - &save-cache-yarn
-    key: v1-yarn-packages-{{ checksum "yarn.lock" }}
-    paths:
-      - ~/.cache/yarn
+    save_cache:
+      key: v1-yarn-packages-{{ checksum "yarn.lock" }}
+      paths:
+        - ~/.cache/yarn
   - &restore-cache-yarn
-    name: Restore Yarn Package Cache
-    keys:
-      - v1-yarn-packages-{{ checksum "yarn.lock" }}
-  - &save-cache-detox
-    key: v1-detox-{{ checksum "yarn.lock"}}
-    paths:
-      - node_modules
-      - ios/Pods
+    restore_cache:
+      name: Restore Yarn Package Cache
+      keys:
+        - v1-yarn-packages-{{ checksum "yarn.lock" }}
+  - &save-cache-detox-pods
+    save_cache:
+      key: v1-detox-{{ checksum "yarn.lock"}}
+      paths:
+        - node_modules
+        - ios/Pods
   - &restore-cache-detox
-    name: Restore Yarn Package Cache
-    keys:
-      - v1-detox-{{ checksum "yarn.lock"}}
-  - &save_android_build_cache
+    restore_cache:
+      name: Restore Yarn Package Cache
+      keys:
+        - v1-detox-{{ checksum "yarn.lock"}}
+  - &save-android-build-cache
     save_cache:
       paths:
         - ~/.gradle/caches
@@ -24,11 +28,11 @@ aliases:
         - ~/.android/build-cache
       key: v1-gradle-build-cache-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-{{ checksum "yarn.lock" }}
       when: always # Ensures build assets are cached even on failed builds
-  - &restore_android_build_cache
+  - &restore-android-build-cache
     restore_cache:
       keys:
         - v1-gradle-build-cache-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-{{ checksum "yarn.lock" }}
-  - &attach_workspace
+  - &attach-workspace
     attach_workspace:
       at: ~/react-native-url-polyfill
 
@@ -56,7 +60,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache: *restore-cache-yarn
+      - *restore-cache-yarn
       - run:
           name: Yarn version
           command: yarn -v
@@ -64,29 +68,29 @@ jobs:
           name: Yarn Install
           command: |
             yarn install --frozen-lockfile --no-progress --non-interactive --cache-folder ~/.cache/yarn
-      - save_cache: *save-cache-yarn
+      - *save-cache-yarn
       - persist_to_workspace:
           root: .
           paths: .
   lint:
     <<: *defaults
     steps:
-      - *attach_workspace
+      - *attach-workspace
       - run:
           name: Lint
           command: yarn lint
   test-js:
     <<: *defaults
     steps:
-      - *attach_workspace
+      - *attach-workspace
       - run:
           name: Run Jest
           command: yarn test
   test-ios:
     <<: *ios
     steps:
-      - *attach_workspace
-      - restore_cache: *restore-cache-detox
+      - *attach-workspace
+      - *restore-cache-detox
       - run:
           name: Yarn version
           command: yarn -v
@@ -111,19 +115,20 @@ jobs:
       - run:
           name: Run Detox on iOS
           command: yarn e2e:ios
-      - save_cache: *save-cache-detox
+      - *save-cache-detox
   test-hermes:
     <<: *android
     steps:
-      - *attach_workspace
-      - *restore_android_build_cache
+      - *attach-workspace
+      - *restore-cache-detox
+      - *restore-android-build-cache
       - run:
           name: Enable Hermes
-          command: sed -i "s/enableHermes:\sfalse/enableHermes:\strue/g" android/app/build.gradle
+          command: sed -i "s/enableHermes: false/enableHermes: true/g" android/app/build.gradle
       - run:
           name: Build APK
           command: cd android && ./gradlew assembleRelease
-      - *save_android_build_cache
+      - *save-android-build-cache
 
 workflows:
   version: 2
@@ -141,4 +146,4 @@ workflows:
             - checkout
       - test-hermes:
           requires:
-            - checkout
+            - test-ios

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ aliases:
         - ios/Pods
   - &restore-cache-detox-pods
     restore_cache:
-      name: Restore Detox Pods Cache
+      name: Restoring Detox Pods Cache
       keys:
         - v1-detox-pods-{{ checksum "yarn.lock"}}
   - &save-cache-detox-yarn
@@ -26,7 +26,7 @@ aliases:
         - node_modules
   - &restore-cache-detox-yarn
     restore_cache:
-      name: Restore Detox Yarn Package Cache
+      name: Restoring Detox Yarn Package Cache
       keys:
         - v1-detox-yarn-{{ checksum "yarn.lock"}}
   - &save-android-build-cache
@@ -39,6 +39,7 @@ aliases:
       when: always # Ensures build assets are cached even on failed builds
   - &restore-android-build-cache
     restore_cache:
+      name: Restoring Android & Gradle cache
       keys:
         - v1-gradle-build-cache-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-{{ checksum "yarn.lock" }}
   - &attach-workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,18 @@ aliases:
     name: Restore Yarn Package Cache
     keys:
       - v1-detox-{{ checksum "yarn.lock"}}
+  - &save_android_build_cache
+    save_cache:
+      paths:
+        - ~/.gradle/caches
+        - ~/.gradle/wrapper
+        - ~/.android/build-cache
+      key: v1-gradle-build-cache-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-{{ checksum "yarn.lock" }}
+      when: always # Ensures build assets are cached even on failed builds
+  - &restore_android_build_cache
+    restore_cache:
+      keys:
+        - v1-gradle-build-cache-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-{{ checksum "yarn.lock" }}
   - &attach_workspace
     attach_workspace:
       at: ~/react-native-url-polyfill
@@ -29,6 +41,14 @@ ios: &ios
   working_directory: ~/react-native-url-polyfill/detox
   macos:
     xcode: 11
+
+android: &android
+  working_directory: ~/react-native-url-polyfill/detox
+  docker:
+    - image: circleci/android:api-29-node
+  environment:
+    JAVA_TOOL_OPTIONS: '-Xmx1536m'
+    GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2'
 
 version: 2
 jobs:
@@ -92,6 +112,18 @@ jobs:
           name: Run Detox on iOS
           command: yarn e2e:ios
       - save_cache: *save-cache-detox
+  test-hermes:
+    <<: *android
+    steps:
+      - *attach_workspace
+      - *restore_android_build_cache
+      - run:
+          name: Enable Hermes
+          command: sed -i "s/enableHermes:\sfalse/enableHermes:\strue/g" android/app/build.gradle
+      - run:
+          name: Build APK
+          command: cd android && ./gradlew assembleRelease
+      - *save_android_build_cache
 
 workflows:
   version: 2
@@ -105,5 +137,8 @@ workflows:
           requires:
             - checkout
       - test-ios:
+          requires:
+            - checkout
+      - test-hermes:
           requires:
             - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,17 +9,26 @@ aliases:
       name: Restore Yarn Package Cache
       keys:
         - v1-yarn-packages-{{ checksum "yarn.lock" }}
-  - &save-cache-detox
+  - &save-cache-detox-pods
     save_cache:
-      key: v1-detox-{{ checksum "yarn.lock"}}
+      key: v1-detox-pods-{{ checksum "yarn.lock"}}
+      paths:
+        - ios/Pods
+  - &restore-cache-detox-pods
+    restore_cache:
+      name: Restore Detox Pods Cache
+      keys:
+        - v1-detox-pods-{{ checksum "yarn.lock"}}
+  - &save-cache-detox-yarn
+    save_cache:
+      key: v1-detox-yarn-{{ checksum "yarn.lock"}}
       paths:
         - node_modules
-        - ios/Pods
-  - &restore-cache-detox
+  - &restore-cache-detox-yarn
     restore_cache:
-      name: Restore Yarn Package Cache
+      name: Restore Detox Yarn Package Cache
       keys:
-        - v1-detox-{{ checksum "yarn.lock"}}
+        - v1-detox-yarn-{{ checksum "yarn.lock"}}
   - &save-android-build-cache
     save_cache:
       paths:
@@ -90,7 +99,8 @@ jobs:
     <<: *ios
     steps:
       - *attach-workspace
-      - *restore-cache-detox
+      - *restore-cache-detox-yarn
+      - *restore-cache-detox-pods
       - run:
           name: Yarn version
           command: yarn -v
@@ -98,6 +108,7 @@ jobs:
           name: Yarn Install
           command: |
             yarn install --frozen-lockfile --no-progress --non-interactive --cache-folder ~/.cache/yarn
+      - *save-cache-detox-yarn
       - run:
           name: Install Detox
           command: |
@@ -112,16 +123,24 @@ jobs:
       - run:
           name: Install Pods
           command: cd ios && pod install
+      - *save-cache-detox-pods
       - run:
           name: Run Detox on iOS
           command: yarn e2e:ios
-      - *save-cache-detox
   test-hermes:
     <<: *android
     steps:
       - *attach-workspace
-      - *restore-cache-detox
+      - *restore-cache-detox-yarn
       - *restore-android-build-cache
+      - run:
+          name: Yarn version
+          command: yarn -v
+      - run:
+          name: Yarn Install
+          command: |
+            yarn install --frozen-lockfile --no-progress --non-interactive --cache-folder ~/.cache/yarn
+      - *save-cache-detox-yarn
       - run:
           name: Enable Hermes
           command: sed -i "s/enableHermes:\sfalse/enableHermes:\strue/g" android/app/build.gradle
@@ -146,4 +165,4 @@ workflows:
             - checkout
       - test-hermes:
           requires:
-            - test-ios
+            - checkout


### PR DESCRIPTION
Add a CircleCI config to build a React Native with Hermes enabled.

This is expected to fail until we fix it.

cc @lb90.