### PR TITLE
Update whatwg-url to add punycode as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 react-native-url-polyfill is a full implementation of the WHATWG [URL Standard](https://url.spec.whatwg.org/) optimized for React Native.
 
-- **Lightweight**. Instead of using directly [`whatwg-url`](https://github.com/jsdom/whatwg-url), this polyfill uses a forked version ([`whatwg-url-without-unicode`](https://github.com/charpeni/whatwg-url)) where unicode support has been stripped out — Going down from [372 KB](https://bundlephobia.com/result?p=whatwg-url@8.0.0) to [41 KB](https://bundlephobia.com/result?p=whatwg-url-without-unicode@8.0.0-2).
+- **Lightweight**. Instead of using directly [`whatwg-url`](https://github.com/jsdom/whatwg-url), this polyfill uses a forked version ([`whatwg-url-without-unicode`](https://github.com/charpeni/whatwg-url)) where unicode support has been stripped out — Going down from [372 KB](https://bundlephobia.com/result?p=whatwg-url@8.0.0) to [40.9 KB](https://bundlephobia.com/result?p=whatwg-url-without-unicode@8.0.0-3).
 - **Trustworthy**. Follows closely the URL Standard spec, and relys on unit tests and Detox e2e tests within [React Native](https://github.com/facebook/react-native).
 - **Blob support**. Supports React Native's Blob without additional steps.
 - **Hermes support**. Supports [Hermes](https://github.com/facebook/hermes), a JavaScript engine optimized for running React Native on Android.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "author": "Nicolas Charpentier <nicolas.charpentier079@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "whatwg-url-without-unicode": "8.0.0-2"
+    "whatwg-url-without-unicode": "8.0.0-3"
   },
   "devDependencies": {
     "@react-native-community/eslint-config": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7791,12 +7791,13 @@ whatwg-mimetype@^2.3.0:
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
 
-whatwg-url-without-unicode@8.0.0-2:
-  version "8.0.0-2"
-  resolved "https://registry.yarnpkg.com/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-2.tgz#c251148656a828bb06e2aa8da76fa798cb090f13"
-  integrity sha512-4ee8FO/DAV9t3spslPQbsGpVHWvkW2BjF73NuO3wShoz9L7UysTft1W+d7fsTjVOFbLYP0qjFvtsGU3b4xRP0w==
+whatwg-url-without-unicode@8.0.0-3:
+  version "8.0.0-3"
+  resolved "https://registry.yarnpkg.com/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz#ab6df4bf6caaa6c85a59f6e82c026151d4bb376b"
+  integrity sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==
   dependencies:
     buffer "^5.4.3"
+    punycode "^2.1.1"
     webidl-conversions "^5.0.0"
 
 whatwg-url@^8.0.0:


### PR DESCRIPTION
Related to #140. 

`whatwg-url` depends on `punycode` but it wasn't specified as a dependency and was magically working because of a transitive dependency of `eslint` and `jest`.