### PR TITLE
Fix ArrayBuffer.prototype.byteLength for iOS 10

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+import './js/ios10Fix';
+
 import {polyfillGlobal} from 'react-native/Libraries/Utilities/PolyfillFunctions';
 
 import {name, version} from './package.json';

--- a/js/ios10Fix.js
+++ b/js/ios10Fix.js
@@ -1,0 +1,24 @@
+/**
+ * There's a bug happening on iOS 10 where `ArrayBuffer.prototype.byteLength`
+ * is not defined, but present on the object returned by the function/constructor
+ * See https://github.com/charpeni/react-native-url-polyfill/issues/190
+ * */
+
+import {Platform} from 'react-native';
+
+const majorVersionIOS = parseInt(Platform.Version, 10);
+
+if (Platform.OS === 'ios' && majorVersionIOS === 10) {
+  if (
+    Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, 'byteLength') == null
+  ) {
+    // eslint-disable-next-line no-extend-native
+    Object.defineProperty(ArrayBuffer.prototype, 'byteLength', {
+      configurable: true,
+      enumerable: false,
+      get() {
+        return null;
+      },
+    });
+  }
+}


### PR DESCRIPTION
Fixes #190.

Not sure why, but `ArrayBuffer.prototype.byteLength` is not defined on iOS 10. It seems like `ArrayBuffer` is a function that will return an object with the expected properties. We should be able to fake it without drawbacks.