### PR TITLE
Fix createObjectURL

### DIFF
--- a/detox/rn-0.60/App.js
+++ b/detox/rn-0.60/App.js
@@ -27,6 +27,15 @@ const App: () => React$Node = () => {
             ).href
           }
         </Text>
+        <Text testID="url-test-3">
+          {URL.createObjectURL({
+            data: {
+              blobId: 1,
+              offset: 32,
+            },
+            size: 64,
+          })}
+        </Text>
       </SafeAreaView>
     </>
   );

--- a/detox/rn-0.60/android/app/src/main/AndroidManifest.xml
+++ b/detox/rn-0.60/android/app/src/main/AndroidManifest.xml
@@ -10,6 +10,11 @@
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
       android:theme="@style/AppTheme">
+      <provider
+         android:name="com.facebook.react.modules.blob.BlobProvider"
+         android:authorities="@string/blob_provider_authority"
+         android:exported="false"
+      />
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"

--- a/detox/rn-0.60/android/app/src/main/res/values/strings.xml
+++ b/detox/rn-0.60/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">Detox</string>
+    <string name="blob_provider_authority">com.detox.blob</string>
 </resources>

--- a/detox/rn-0.60/e2e/url-polyfill.spec.js
+++ b/detox/rn-0.60/e2e/url-polyfill.spec.js
@@ -24,4 +24,10 @@ describe('URL Polyfill', () => {
       'https://facebook.github.io/react-native/img/header_logo.png',
     );
   });
+
+  it('should handle test 3', async () => {
+    await expect(element(by.id('url-test-3'))).toHaveText(
+      'blob:1?offset=32&size=64',
+    );
+  });
 });

--- a/detox/rn-0.61/App.js
+++ b/detox/rn-0.61/App.js
@@ -27,6 +27,15 @@ const App: () => React$Node = () => {
             ).href
           }
         </Text>
+        <Text testID="url-test-3">
+          {URL.createObjectURL({
+            data: {
+              blobId: 1,
+              offset: 32,
+            },
+            size: 64,
+          })}
+        </Text>
       </SafeAreaView>
     </>
   );

--- a/detox/rn-0.61/e2e/url-polyfill.spec.js
+++ b/detox/rn-0.61/e2e/url-polyfill.spec.js
@@ -24,4 +24,10 @@ describe('URL Polyfill', () => {
       'https://facebook.github.io/react-native/img/header_logo.png',
     );
   });
+
+  it('should handle test 3', async () => {
+    await expect(element(by.id('url-test-3'))).toHaveText(
+      'blob:1?offset=32&size=64',
+    );
+  });
 });

--- a/detox/rn-0.62/App.js
+++ b/detox/rn-0.62/App.js
@@ -27,6 +27,15 @@ const App: () => React$Node = () => {
             ).href
           }
         </Text>
+        <Text testID="url-test-3">
+          {URL.createObjectURL({
+            data: {
+              blobId: 1,
+              offset: 32,
+            },
+            size: 64,
+          })}
+        </Text>
       </SafeAreaView>
     </>
   );

--- a/detox/rn-0.62/e2e/url-polyfill.spec.js
+++ b/detox/rn-0.62/e2e/url-polyfill.spec.js
@@ -24,4 +24,10 @@ describe('URL Polyfill', () => {
       'https://facebook.github.io/react-native/img/header_logo.png',
     );
   });
+
+  it('should handle test 3', async () => {
+    await expect(element(by.id('url-test-3'))).toHaveText(
+      'blob:1?offset=32&size=64',
+    );
+  });
 });

--- a/detox/rn-0.63/App.js
+++ b/detox/rn-0.63/App.js
@@ -27,6 +27,15 @@ const App: () => React$Node = () => {
             ).href
           }
         </Text>
+        <Text testID="url-test-3">
+          {URL.createObjectURL({
+            data: {
+              blobId: 1,
+              offset: 32,
+            },
+            size: 64,
+          })}
+        </Text>
       </SafeAreaView>
     </>
   );

--- a/detox/rn-0.63/android/app/src/main/AndroidManifest.xml
+++ b/detox/rn-0.63/android/app/src/main/AndroidManifest.xml
@@ -10,6 +10,11 @@
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
       android:theme="@style/AppTheme">
+      <provider
+         android:name="com.facebook.react.modules.blob.BlobProvider"
+         android:authorities="@string/blob_provider_authority"
+         android:exported="false"
+      />
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"

--- a/detox/rn-0.63/android/app/src/main/res/values/strings.xml
+++ b/detox/rn-0.63/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">Detox</string>
+    <string name="blob_provider_authority">com.detox.blob</string>
 </resources>

--- a/detox/rn-0.63/e2e/url-polyfill.spec.js
+++ b/detox/rn-0.63/e2e/url-polyfill.spec.js
@@ -24,4 +24,10 @@ describe('URL Polyfill', () => {
       'https://facebook.github.io/react-native/img/header_logo.png',
     );
   });
+
+  it('should handle test 3', async () => {
+    await expect(element(by.id('url-test-3'))).toHaveText(
+      'blob:1?offset=32&size=64',
+    );
+  });
 });

--- a/js/URL.js
+++ b/js/URL.js
@@ -1,19 +1,14 @@
-import {URL as whatwgUrl} from 'whatwg-url-without-unicode';
-
 import {NativeModules} from 'react-native';
-
-const {NativeBlobModule} = NativeModules;
+import {URL as whatwgUrl} from 'whatwg-url-without-unicode';
 
 let BLOB_URL_PREFIX = null;
 
-if (
-  NativeBlobModule &&
-  typeof NativeBlobModule.getConstants().BLOB_URI_SCHEME === 'string'
-) {
-  const constants = NativeBlobModule.getConstants();
-  BLOB_URL_PREFIX = constants.BLOB_URI_SCHEME + ':';
-  if (typeof constants.BLOB_URI_HOST === 'string') {
-    BLOB_URL_PREFIX += `//${constants.BLOB_URI_HOST}/`;
+const {BlobModule} = NativeModules;
+
+if (BlobModule && typeof BlobModule.BLOB_URI_SCHEME === 'string') {
+  BLOB_URL_PREFIX = BlobModule.BLOB_URI_SCHEME + ':';
+  if (typeof BlobModule.BLOB_URI_HOST === 'string') {
+    BLOB_URL_PREFIX += `//${BlobModule.BLOB_URI_HOST}/`;
   }
 }
 


### PR DESCRIPTION
Resolves #223.

`NativeBlobModule` was previously always `undefined` and I can't set up detox tests properly to read the version of React Native, so instead of having a conditional based on React Native's version I went back to the initial implementation with `BlobModule` instead of `NativeBlobModule` (TurboModule).

Tested on RN 0.60 and RN 0.63 on iOS and Android, everything is working as expected.

cc @acostalima @kennym I added both of you as co-authors.