### PR TITLE
Bump versions on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ aliases:
         - yarn-packages-{{ .Environment.CACHE_VERSION }}-{{ checksum "yarn.lock" }}
   - &save-cache-detox-env
     save_cache:
-      key: detox-env-{{ .Environment.CACHE_VERSION }}-{{ arch }}-<< *xcode-version >>-{{ .Environment.CIRCLE_WORKING_DIRECTORY }}
+      key: detox-env-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ .Environment.XCODE_VERSION }}-{{ .Environment.CIRCLE_WORKING_DIRECTORY }}
       paths:
         - /usr/local/Homebrew
         - ~/Library/Caches/Homebrew
@@ -22,7 +22,7 @@ aliases:
     restore_cache:
       name: Restoring Detox Env Cache
       keys:
-        - detox-env-{{ .Environment.CACHE_VERSION }}-{{ arch }}-<< *xcode-version >>-{{ .Environment.CIRCLE_WORKING_DIRECTORY }}
+        - detox-env-{{ .Environment.CACHE_VERSION }}-{{ arch }}-{{ .Environment.XCODE_VERSION }}-{{ .Environment.CIRCLE_WORKING_DIRECTORY }}
   - &save-cache-detox-app
     save_cache:
       key: detox-app-{{ .Environment.CACHE_VERSION }}-{{ checksum "yarn.lock"}}
@@ -61,11 +61,13 @@ executors:
       xcode: 11.7.0
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
+      XCODE_VERSION: 11.7.0
   xcode:
     macos:
       xcode: *xcode-version
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
+      XCODE_VERSION: *xcode-version
   android:
     docker:
       - image: circleci/android:api-30-node


### PR DESCRIPTION
- Bumped Node to the latest LTS (16)
- Bumped Xcode from 12.4 to 12.5.1
- Bumped Android API from 29 to 30 (React Native 0.65 and 0.66 are requiring the API 30)