### PR TITLE
Remove usage of RN's polyfillGlobal

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,7 +221,7 @@ workflows:
           requires:
             - checkout
       - test-js:
-          name: test-rn-0.60
+          name: test-js-0.60
           parameters:
             react-native-version: '0.60.6'
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,9 +142,18 @@ jobs:
           name: Lint
           command: yarn lint
   test-js:
+    parameters:
+      react-native-version:
+        type: string
     executor: default
     steps:
       - *attach-workspace
+      - when:
+          condition: << parameters.react-native-version >>
+          steps:
+            - run:
+                name: Overriding react-native version
+                command: yarn add --dev react-native@<< parameters.react-native-version >>
       - run:
           name: Run Jest
           command: yarn test
@@ -209,6 +218,12 @@ workflows:
           requires:
             - checkout
       - test-js:
+          requires:
+            - checkout
+      - test-js:
+          name: test-rn-0.60
+          parameters:
+            react-native-version: '0.60.6'
           requires:
             - checkout
       - test-ios:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,7 @@ jobs:
     parameters:
       react-native-version:
         type: string
+        default: ''
     executor: default
     steps:
       - *attach-workspace
@@ -222,8 +223,7 @@ workflows:
             - checkout
       - test-js:
           name: test-js-0.60
-          parameters:
-            react-native-version: '0.60.6'
+          react-native-version: '0.60.6'
           requires:
             - checkout
       - test-ios:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,11 +221,6 @@ workflows:
       - test-js:
           requires:
             - checkout
-      - test-js:
-          name: test-js-0.60
-          react-native-version: '0.60.6'
-          requires:
-            - checkout
       - test-ios:
           name: test-ios-0.60
           executor: xcode-11

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -1,7 +1,3 @@
-jest.mock('react-native/Libraries/Utilities/PolyfillFunctions', () => ({
-  polyfillGlobal: jest.fn(),
-}));
-
 describe('Index', function () {
   it("shouldn't apply URL and URLSearchParams on import", () => {
     expect(global.REACT_NATIVE_URL_POLYFILL).toBeUndefined();

--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 import './js/ios10Fix';
 
-import {polyfillGlobal} from 'react-native/Libraries/Utilities/PolyfillFunctions';
-
 import {name, version} from './package.json';
 
 export * from './js/URL';
@@ -10,9 +8,6 @@ export * from './js/URLSearchParams';
 export function setupURLPolyfill() {
   global.REACT_NATIVE_URL_POLYFILL = `${name}@${version}`;
 
-  polyfillGlobal('URL', () => require('./js/URL').URL);
-  polyfillGlobal(
-    'URLSearchParams',
-    () => require('./js/URLSearchParams').URLSearchParams,
-  );
+  global.URL = require('./js/URL').URL;
+  global.URLSearchParams = require('./js/URLSearchParams').URLSearchParams;
 }


### PR DESCRIPTION
By importing `polyfillGlobal` from React Native's internals, we were subject to breaking changes and had trouble supporting older versions (0.59 & 0.60) in the past.

Removing this in favor of `global.` ~and adding additional tests to run Jest against RN 0.60~.