### PR TITLE
Extract and reuse test components

### DIFF
--- a/platforms/detox/TestPolyfill.js
+++ b/platforms/detox/TestPolyfill.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import {Text} from 'react-native';
+
+const PolyfillTests = () => (
+  <>
+    <Text testID="url-polyfill-version">
+      {global.REACT_NATIVE_URL_POLYFILL}
+    </Text>
+    <Text testID="url-test-1">{new URL('dev', 'https://google.dev').href}</Text>
+    <Text testID="url-test-2">
+      {
+        new URL('https://facebook.github.io/react-native/img/header_logo.png')
+          .href
+      }
+    </Text>
+    <Text testID="url-test-3">
+      {URL.createObjectURL({
+        data: {
+          blobId: 1,
+          offset: 32,
+        },
+        size: 64,
+      })}
+    </Text>
+  </>
+);
+
+export default PolyfillTests;

--- a/platforms/react-native/0.65/App.js
+++ b/platforms/react-native/0.65/App.js
@@ -9,33 +9,14 @@
 import React from 'react';
 import {SafeAreaView, Text, StatusBar} from 'react-native';
 
+import TestPolyfill from '../../detox/TestPolyfill';
+
 const App: () => React$Node = () => {
   return (
     <>
       <StatusBar barStyle="dark-content" />
       <SafeAreaView>
-        <Text testID="url-polyfill-version">
-          {global.REACT_NATIVE_URL_POLYFILL}
-        </Text>
-        <Text testID="url-test-1">
-          {new URL('dev', 'https://google.dev').href}
-        </Text>
-        <Text testID="url-test-2">
-          {
-            new URL(
-              'https://facebook.github.io/react-native/img/header_logo.png',
-            ).href
-          }
-        </Text>
-        <Text testID="url-test-3">
-          {URL.createObjectURL({
-            data: {
-              blobId: 1,
-              offset: 32,
-            },
-            size: 64,
-          })}
-        </Text>
+        <TestPolyfill />
       </SafeAreaView>
     </>
   );

--- a/platforms/react-native/0.66/App.js
+++ b/platforms/react-native/0.66/App.js
@@ -10,33 +10,14 @@ import React from 'react';
 import type {Node} from 'react';
 import {SafeAreaView, Text, StatusBar} from 'react-native';
 
+import TestPolyfill from '../../detox/TestPolyfill';
+
 const App: () => Node = () => {
   return (
     <>
       <StatusBar barStyle="dark-content" />
       <SafeAreaView>
-        <Text testID="url-polyfill-version">
-          {global.REACT_NATIVE_URL_POLYFILL}
-        </Text>
-        <Text testID="url-test-1">
-          {new URL('dev', 'https://google.dev').href}
-        </Text>
-        <Text testID="url-test-2">
-          {
-            new URL(
-              'https://facebook.github.io/react-native/img/header_logo.png',
-            ).href
-          }
-        </Text>
-        <Text testID="url-test-3">
-          {URL.createObjectURL({
-            data: {
-              blobId: 1,
-              offset: 32,
-            },
-            size: 64,
-          })}
-        </Text>
+        <TestPolyfill />
       </SafeAreaView>
     </>
   );


### PR DESCRIPTION
Instead of duplicating the components used by Detox to test this library, let's move it to its own shared component in `platforms/detox`.