### PR TITLE
Remove deprecated Cocoapods Spec mirror repo

### DIFF
--- a/platforms/expo/43/ios/Podfile
+++ b/platforms/expo/43/ios/Podfile
@@ -1,3 +1,5 @@
+source 'https://cdn.cocoapods.org/'
+
 require File.join(File.dirname(`node --print "require.resolve('expo/package.json')"`), "scripts/autolinking")
 require File.join(File.dirname(`node --print "require.resolve('react-native/package.json')"`), "scripts/react_native_pods")
 require File.join(File.dirname(`node --print "require.resolve('@react-native-community/cli-platform-ios/package.json')"`), "native_modules")

--- a/platforms/expo/44/ios/Podfile
+++ b/platforms/expo/44/ios/Podfile
@@ -1,3 +1,5 @@
+source 'https://cdn.cocoapods.org/'
+
 require File.join(File.dirname(`node --print "require.resolve('expo/package.json')"`), "scripts/autolinking")
 require File.join(File.dirname(`node --print "require.resolve('react-native/package.json')"`), "scripts/react_native_pods")
 require File.join(File.dirname(`node --print "require.resolve('@react-native-community/cli-platform-ios/package.json')"`), "native_modules")

--- a/platforms/react-native/0.60/ios/Podfile
+++ b/platforms/react-native/0.60/ios/Podfile
@@ -1,3 +1,5 @@
+source 'https://cdn.cocoapods.org/'
+
 platform :ios, '9.0'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 

--- a/platforms/react-native/0.66/ios/Podfile
+++ b/platforms/react-native/0.66/ios/Podfile
@@ -1,3 +1,5 @@
+source 'https://cdn.cocoapods.org/'
+
 require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 

--- a/platforms/react-native/0.67/ios/Podfile
+++ b/platforms/react-native/0.67/ios/Podfile
@@ -1,3 +1,5 @@
+source 'https://cdn.cocoapods.org/'
+
 require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 


### PR DESCRIPTION
The previous S3 mirror provided for the Cocoapods Spec repo has been removed by CircleCI.

Following CircleCI's advice on [Optimizing Cocoapods](https://circleci.com/docs/2.0/testing-ios/#optimizing-cocoapods).