### PR TITLE
feat: convert mjs import statements to commonjs

### DIFF
--- a/auto.js
+++ b/auto.js
@@ -1,3 +1,3 @@
-import {setupURLPolyfill} from './index';
+const {setupURLPolyfill} = require('./index');
 
 setupURLPolyfill();

--- a/index.js
+++ b/index.js
@@ -1,13 +1,17 @@
-import './js/ios10Fix';
+require('./js/ios10Fix');
+const {URL} = require('./js/URL');
+const {URLSearchParams} = require('./js/URLSearchParams');
+const {name, version} = require('./package.json');
 
-import {name, version} from './package.json';
-
-export * from './js/URL';
-export * from './js/URLSearchParams';
-
-export function setupURLPolyfill() {
+function setupURLPolyfill() {
   global.REACT_NATIVE_URL_POLYFILL = `${name}@${version}`;
 
   global.URL = require('./js/URL').URL;
   global.URLSearchParams = require('./js/URLSearchParams').URLSearchParams;
 }
+
+module.exports = {
+  URL,
+  URLSearchParams,
+  setupURLPolyfill,
+};

--- a/js/URL.js
+++ b/js/URL.js
@@ -1,5 +1,5 @@
-import {NativeModules} from 'react-native';
-import {URL as whatwgUrl} from 'whatwg-url-without-unicode';
+const {NativeModules} = require('react-native');
+const {URL: whatwgUrl} = require('whatwg-url-without-unicode');
 
 let BLOB_URL_PREFIX = null;
 
@@ -48,4 +48,4 @@ whatwgUrl.revokeObjectURL = function revokeObjectURL(url) {
   // Do nothing.
 };
 
-export const URL = whatwgUrl;
+module.exports.URL = whatwgUrl;

--- a/js/URLSearchParams.js
+++ b/js/URLSearchParams.js
@@ -1,1 +1,3 @@
-export {URLSearchParams} from 'whatwg-url-without-unicode';
+const {URLSearchParams} = require('whatwg-url-without-unicode');
+
+module.exports.URLSearchParams = URLSearchParams;

--- a/js/ios10Fix.js
+++ b/js/ios10Fix.js
@@ -4,7 +4,7 @@
  * See https://github.com/charpeni/react-native-url-polyfill/issues/190
  * */
 
-import {Platform} from 'react-native';
+const {Platform} = require('react-native');
 
 const majorVersionIOS = parseInt(Platform.Version, 10);
 


### PR DESCRIPTION
Resovles: #446

this change fixes the issue when using Jest react-native preset against TypeScript, the transpiled code contains unrecognized 'import' statement. Moreover the code pointed by the 'main' entry point should be commonjs module.