### PR TITLE
Remove deprecated/non-working jobs from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,42 +254,6 @@ jobs:
       - run:
           name: Run Detox on iOS
           command: yarn e2e:ios
-  test-expo-ios:
-    parameters:
-      executor:
-        default: xcode
-        type: executor
-      expo-version:
-        type: string
-    executor: << parameters.executor >>
-    working_directory: ~/react-native-url-polyfill/platforms/expo/<< parameters.expo-version >>
-    steps:
-      - attach-workspace
-      - restore-cache-detox-app
-      - install-node
-      - install-yarn-dependencies
-      - install-detox
-      - run:
-          name: Install Pods
-          command: cd ios && pod install --repo-update
-      - run: yarn global add expo-cli
-      - run:
-          name: Build iOS App w/ Expo
-          no_output_timeout: 30m
-          command: npx expo build:ios -t simulator --no-publish --non-interactive
-      - run:
-          name: Make Directory tmp
-          command: mkdir -p tmp
-      - run:
-          name: Downloading .ipa from expo
-          command: curl -o tmp/app.tar.gz "$(npx expo url:ipa --non-interactive)"
-      - run:
-          name: Un-tar app.tar.gz
-          command: tar -xzvf tmp/app.tar.gz -C tmp
-      - run:
-          name: Run Detox on iOS
-          command: yarn test:ios
-      - save-cache-detox-app
   test-expo-web:
     parameters:
       expo-version:
@@ -347,13 +311,6 @@ workflows:
           matrix:
             parameters:
               react-native-version: ['0.67', '0.68']
-          requires:
-            - lint
-            - test-js
-      - test-expo-ios:
-          matrix:
-            parameters:
-              expo-version: ['43', '44']
           requires:
             - lint
             - test-js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,10 +314,10 @@ workflows:
           requires:
             - lint
             - test-js
-      - test-expo-web:
-          matrix:
-            parameters:
-              expo-version: ['43', '44']
-          requires:
-            - lint
-            - test-js
+      # - test-expo-web:
+      #     matrix:
+      #       parameters:
+      #         expo-version: ['43', '44']
+      #     requires:
+      #       - lint
+      #       - test-js


### PR DESCRIPTION
I want to get the repository in a better shape, so the first task to do is to bring CircleCI back to life.

- `test-expo-ios` job doesn't work anymore because `expo build:ios` has been discontinued on January 4, 2023. Let's remove it.
- `test-expo-web` job doesn't work anymore because the webpack configuration doesn't match anymore, probably related to expo CLI being updated and our versions of expo are deprecated now. Let's comment this job for now and try to bring it back when we add examples for the last versions.