### PR TITLE
Don't auto polyfill on web

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ react-native-url-polyfill is an implementation of the WHATWG [URL Standard](http
 - **Blob support**. Supports React Native's Blob without additional steps.
 - **Hermes support**. Supports [Hermes](https://github.com/facebook/hermes), a JavaScript engine optimized for running React Native.
 - **Expo support**. Supports [Expo](https://expo.dev/) and tested against.
+- **Web support**. Most of the time, this polyfill isn't useful on web and therefore using `react-native-url-polyfill/auto` will be no-op on web.
 
 ## Why do we need this?
 

--- a/auto.js
+++ b/auto.js
@@ -1,3 +1,7 @@
+import {Platform} from 'react-native';
+
 import {setupURLPolyfill} from './index';
 
-setupURLPolyfill();
+if (Platform.OS !== 'web') {
+  setupURLPolyfill();
+}


### PR DESCRIPTION
Fixes https://github.com/charpeni/react-native-url-polyfill/issues/366.

We removed usage of `polyfillGlobal` in favor of `globalThis`, but let's go a step further and let's prevent applying the polyfill on web when using `auto`. Calling `setupURLPolyfill` directly will still apply the polyfill as expected.