### PR TITLE
Only default export is available soon

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 import './js/ios10Fix';
 
-import {name, version} from './package.json';
+import packageJson from './package.json';
 
 export * from './js/URL';
 export * from './js/URLSearchParams';
 
 export function setupURLPolyfill() {
-  globalThis.REACT_NATIVE_URL_POLYFILL = `${name}@${version}`;
+  globalThis.REACT_NATIVE_URL_POLYFILL = `${packageJson.name}@${packageJson.version}`;
 
   globalThis.URL = require('./js/URL').URL;
   globalThis.URLSearchParams = require('./js/URLSearchParams').URLSearchParams;


### PR DESCRIPTION
Fixes #448.

Fix for the following error:

```
Should not import the named export 'name' (imported as 'name') from default-exporting module (only default export is available soon)
```