### PR TITLE
Inject package version before `npm publish` to reduce a bundle size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,8 @@ commands:
           name: Yarn Install
           command: |
             yarn install --frozen-lockfile --no-progress --non-interactive --cache-folder ~/.cache/yarn
+            cd ~/react-native-url-polyfill && yarn prepublishOnly
+
   install-detox:
     steps:
       - restore-cache-detox-env

--- a/index.js
+++ b/index.js
@@ -1,12 +1,10 @@
 import './js/ios10Fix';
 
-import packageJson from './package.json';
-
 export * from './js/URL';
 export * from './js/URLSearchParams';
 
 export function setupURLPolyfill() {
-  globalThis.REACT_NATIVE_URL_POLYFILL = `${packageJson.name}@${packageJson.version}`;
+  globalThis.REACT_NATIVE_URL_POLYFILL = '<INJECT_VERSION>';
 
   globalThis.URL = require('./js/URL').URL;
   globalThis.URLSearchParams = require('./js/URLSearchParams').URLSearchParams;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lint": "eslint .",
     "type-check": "tsc index.d.ts",
     "prepare": "husky install",
+    "prepublishOnly": "node scripts/prepublish",
     "bundle-size": "node scripts/bundle-size"
   },
   "author": "Nicolas Charpentier <nicolas.charpentier079@gmail.com>",

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -1,0 +1,12 @@
+#!/usr/bin/node
+const fs = require('node:fs');
+
+const packageJson = require('../package.json');
+const path = require.resolve('../index.js');
+
+fs.writeFileSync(
+  path,
+  fs
+    .readFileSync(path, 'utf8')
+    .replace('<INJECT_VERSION>', `${packageJson.name}@${packageJson.version}`),
+);


### PR DESCRIPTION
Fix for https://github.com/charpeni/react-native-url-polyfill/issues/483

**To test:**
1. Run `npm publish --dry-run`
2. Check `index.js`