### PR TITLE
Update Node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 aliases:
-  - &node-version '22.14.0'
+  - &node-version '22.19.0'
   - &yarn-version '1.22.22'
 
 orbs:
@@ -12,13 +12,13 @@ orbs:
 executors:
   node:
     docker:
-      - image: cimg/node:22.14.0
+      - image: cimg/node:22.19.0
     working_directory: ~/react-native-url-polyfill
     environment:
       NODE_OPTIONS: '--openssl-legacy-provider'
   node-browsers:
     docker:
-      - image: cimg/node:22.14.0-browsers
+      - image: cimg/node:22.19.0-browsers
     environment:
       NODE_OPTIONS: '--openssl-legacy-provider'
   android:


### PR DESCRIPTION
This pull request updates the Node.js version used in the CircleCI configuration to ensure compatibility with the latest features and security patches.

CircleCI configuration updates:

* Updated the Node.js version alias from `'22.14.0'` to `'22.19.0'` in `.circleci/config.yml` to use a newer, supported version.
* Changed the Docker image references for both the `node` and `node-browsers` executors from `cimg/node:22.14.0` and `cimg/node:22.14.0-browsers` to `cimg/node:22.19.0` and `cimg/node:22.19.0-browsers` respectively.