### PR TITLE
Update Xcode version to `16.4.0` in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -288,7 +288,7 @@ workflows:
       - test-ios:
           name: test-ios-0.78
           react-native-version: '0.78'
-          xcode-version: 16.2.0
+          xcode-version: 16.4.0
           legacy-pods-install: true
           requires:
             - lint


### PR DESCRIPTION
`16.2.0` is now deprecated and removed, let's upgrade to `16.4.0`.