### PR TITLE
proposal: Replace `whatwg-url-without-unicode` with `whatwg-url-minimum`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A lightweight and trustworthy URL polyfill for React Native, based on the WHATWG
 
 <br />
 
-- **Lightweight**. Uses a forked version of [`whatwg-url`](https://github.com/jsdom/whatwg-url) ([`whatwg-url-without-unicode`](https://github.com/charpeni/whatwg-url)) where Unicode support has been stripped out—Going down from [372 KB](https://bundlephobia.com/result?p=whatwg-url@8.0.0) to [40.9 KB](https://bundlephobia.com/result?p=whatwg-url-without-unicode@8.0.0-3).
+- **Lightweight**. Uses a forked version of [`whatwg-url`](https://github.com/jsdom/whatwg-url) ([`whatwg-url-minimum`](https://github.com/kitten/whatwg-url-minimum)) where Unicode support has been stripped out—Going down from [372 KB](https://bundlephobia.com/result?p=whatwg-url@8.0.0) to [18.1 KB](https://bundlejs.com/?q=whatwg-url-minimum).
 - **Trustworthy**. Follows the URL Standard spec, and relies on unit tests and Detox e2e tests within [React Native](https://github.com/facebook/react-native).
 - **Blob support**. Supports React Native's Blob without additional steps.
 - **Hermes support**. Supports [Hermes](https://github.com/facebook/hermes), a JavaScript engine optimized for running React Native.

--- a/js/URL.js
+++ b/js/URL.js
@@ -1,5 +1,5 @@
 import {NativeModules} from 'react-native';
-import {URL as whatwgUrl} from 'whatwg-url-without-unicode';
+import {URL as whatwgUrl} from 'whatwg-url-minimum';
 
 let BLOB_URL_PREFIX = null;
 

--- a/js/URLSearchParams.js
+++ b/js/URLSearchParams.js
@@ -1,1 +1,1 @@
-export {URLSearchParams} from 'whatwg-url-without-unicode';
+export {URLSearchParams} from 'whatwg-url-minimum';

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "author": "Nicolas Charpentier <nicolas.charpentier079@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "whatwg-url-without-unicode": "8.0.0-3"
+    "whatwg-url-minimum": "^0.1.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2925,7 +2925,7 @@ buffer-from@^1.0.0:
   resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
-buffer@^5.4.3, buffer@^5.5.0:
+buffer@^5.5.0:
   version "5.7.1"
   resolved "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz"
   integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
@@ -6279,7 +6279,7 @@ proper-lockfile@^3.0.2:
     retry "^0.12.0"
     signal-exit "^3.0.2"
 
-punycode@^2.1.0, punycode@^2.1.1:
+punycode@^2.1.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz"
   integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
@@ -7357,24 +7357,15 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-webidl-conversions@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz"
-  integrity sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==
-
 whatwg-fetch@^3.0.0:
   version "3.6.2"
   resolved "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz"
   integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
 
-whatwg-url-without-unicode@8.0.0-3:
-  version "8.0.0-3"
-  resolved "https://registry.npmjs.org/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz"
-  integrity sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==
-  dependencies:
-    buffer "^5.4.3"
-    punycode "^2.1.1"
-    webidl-conversions "^5.0.0"
+whatwg-url-minimum@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/whatwg-url-minimum/-/whatwg-url-minimum-0.1.1.tgz#df90eba931c3624c6a74dd9b7d39634390f2b67f"
+  integrity sha512-u2FNVjFVFZhdjb502KzXy1gKn1mEisQRJssmSJT8CPhZdZa0AP6VCbWlXERKyGu0l09t0k50FiDiralpGhBxgA==
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Summary

> [!NOTE]
> This is offered up as a proposal, and I'm not implying that this should be merged, and offer no opinion on this :v: Mainly, I'm opening this so it's tracked against this project as a difference of environments between `react-native-url-polyfill` and Expo

`react-native-url-polyfill` and `expo/winter` for an extended period shared the `whatwg-url-without-unicode` package in their implementations, where Expo's core library for globals just bypassed `react-native-url-polyfill` but used the same underlying implementation.]

We've changed this in a later PR that has shipped in SDK 55: https://github.com/expo/expo/pull/42706

`whatwg-url-minimum` is a derivative (rather than a clean fork) I'm maintaining for Expo that re-implements similar changes to `whatwg-url-without-unicode`. While it's also slimmed down and altered, it also has a few additions that make it pass more Web Platform Tests, as per: https://github.com/kitten/whatwg-url-minimum/blob/c67b1f98ed788e54d587c94c307c652cc2f5308c/src/url-state-machine.ts#L133-L142

The main goal was to maintain a derivative that's further slimmed down and refactored, but also is tested against Web Platform Tests, so we're tracking the exact points it diverges from the specification.

As such it also addresses: https://github.com/charpeni/react-native-url-polyfill/issues/462

To repeat the note, this won't need to be merged, but I'd love for there to be a PR that tracks that the implementations have diverged, since we're aware of some apps that redundantly use `react-native-url-polyfill` in Expo. There might also be libraries that assume that both use the same.

## Set of changes

- Replace `whatwg-url-without-unicode` with `whatwg-url-minimum`
- Update main readme