### PR TITLE
Add React Native 0.84 Android Detox coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,6 +289,9 @@ workflows:
             - lint
             - test-js
             - test-ios-0.84
+          filters:
+            branches:
+              ignore: main
       - test-ios:
           name: test-ios-0.78
           react-native-version: '0.78'
@@ -298,6 +301,9 @@ workflows:
             - lint
             - test-js
             - test-ios-0.84
+          filters:
+            branches:
+              ignore: main
       - test-ios:
           name: test-ios-0.81
           react-native-version: '0.81'
@@ -306,17 +312,32 @@ workflows:
             - lint
             - test-js
             - test-ios-0.84
+          filters:
+            branches:
+              ignore: main
+      - approve-ios-tests:
+          type: approval
+          requires:
+            - test-android-0.84
+          filters:
+            branches:
+              ignore: main
       - test-ios:
           name: test-ios-0.84
           react-native-version: '0.84'
-          xcode-version: "26.6"
+          xcode-version: '26.6'
           requires:
             - lint
             - test-js
+            - test-android-0.84
+            - approve-ios-tests
+          filters:
+            branches:
+              ignore: main
       - test-android:
           matrix:
             parameters:
-              react-native-version: ['0.68', '0.72', '0.78']
+              react-native-version: ['0.68', '0.72', '0.78', '0.84']
           requires:
             - lint
             - test-js
@@ -326,3 +347,49 @@ workflows:
               react-native-version: ['0.68']
           requires:
             - test-android-<< matrix.react-native-version >>
+      - test-ios:
+          name: test-ios-0.84-main
+          react-native-version: '0.84'
+          xcode-version: '26.6'
+          requires:
+            - lint
+            - test-js
+            - test-android-0.84
+          filters:
+            branches:
+              only: main
+      - test-ios:
+          name: test-ios-0.72-main
+          react-native-version: '0.72'
+          xcode-version: 15.4.0
+          legacy-pods-install: true
+          requires:
+            - lint
+            - test-js
+            - test-ios-0.84-main
+          filters:
+            branches:
+              only: main
+      - test-ios:
+          name: test-ios-0.78-main
+          react-native-version: '0.78'
+          xcode-version: 16.4.0
+          legacy-pods-install: true
+          requires:
+            - lint
+            - test-js
+            - test-ios-0.84-main
+          filters:
+            branches:
+              only: main
+      - test-ios:
+          name: test-ios-0.81-main
+          react-native-version: '0.81'
+          xcode-version: 16.4.0
+          requires:
+            - lint
+            - test-js
+            - test-ios-0.84-main
+          filters:
+            branches:
+              only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,10 +246,6 @@ jobs:
       - run:
           name: Run Detox
           command: yarn e2e:android
-      - run:
-          name: Collect Android logs on failure
-          command: adb logcat -d -v threadtime
-          when: on_fail
       - android/save-gradle-cache:
           cache-prefix: v1a
   test-hermes-android:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,6 +246,10 @@ jobs:
       - run:
           name: Run Detox
           command: yarn e2e:android
+      - run:
+          name: Collect Android logs on failure
+          command: adb logcat -d -v threadtime
+          when: on_fail
       - android/save-gradle-cache:
           cache-prefix: v1a
   test-hermes-android:

--- a/platforms/react-native/0.84/android/app/build.gradle
+++ b/platforms/react-native/0.84/android/app/build.gradle
@@ -119,6 +119,6 @@ dependencies {
         implementation jscFlavor
     }
 
-    androidTestImplementation('com.wix:detox:20.51.4')
+    androidTestImplementation('com.wix:detox:+')
     implementation 'androidx.appcompat:appcompat:1.1.0'
 }

--- a/platforms/react-native/0.84/android/app/build.gradle
+++ b/platforms/react-native/0.84/android/app/build.gradle
@@ -119,6 +119,6 @@ dependencies {
         implementation jscFlavor
     }
 
-    androidTestImplementation('com.wix:detox:+')
+    androidTestImplementation('com.wix:detox:20.51.4')
     implementation 'androidx.appcompat:appcompat:1.1.0'
 }

--- a/platforms/react-native/0.84/android/app/src/main/AndroidManifest.xml
+++ b/platforms/react-native/0.84/android/app/src/main/AndroidManifest.xml
@@ -10,7 +10,8 @@
       android:allowBackup="false"
       android:theme="@style/AppTheme"
       android:usesCleartextTraffic="${usesCleartextTraffic}"
-      android:supportsRtl="true">
+      android:supportsRtl="true"
+      android:networkSecurityConfig="@xml/network_security_config">
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"

--- a/platforms/react-native/0.84/android/app/src/main/res/xml/network_security_config.xml
+++ b/platforms/react-native/0.84/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">10.0.2.2</domain>
+        <domain includeSubdomains="true">localhost</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
## Summary
- Add Detox Android coverage for React Native `0.84`.
- Permit the Detox cleartext WebSocket bridge only to the Android emulator host and `localhost`.
- Make `test-ios-0.84` run after its Android counterpart succeeds.
- Require approval before running macOS Detox jobs on non-`main` branches.
- Keep the full iOS Detox chain automatic after merges to `main`.

## Notes
The React Native `0.84` fixture uses React Native `0.84.1`, React `19.2.3`, Android API/`compileSdk` `36`, Gradle `9.0.0`, and Detox `20.51.4`.