### PR TITLE
Optimize repeated `URLSearchParams` mutations

### DIFF
--- a/js/URL.ts
+++ b/js/URL.ts
@@ -1761,13 +1761,17 @@ export class URLSearchParams {
     name = toUSVString(name);
     const normalizedValue =
       value === undefined ? undefined : toUSVString(value);
-    this._list = this._list.filter(
-      (pair) =>
-        !(
-          pair[0] === name &&
-          (normalizedValue === undefined || pair[1] === normalizedValue)
-        ),
-    );
+    let writeIndex = 0;
+    for (let readIndex = 0; readIndex < this._list.length; readIndex++) {
+      const pair = this._list[readIndex];
+      if (
+        pair[0] !== name ||
+        (normalizedValue !== undefined && pair[1] !== normalizedValue)
+      ) {
+        this._list[writeIndex++] = pair;
+      }
+    }
+    this._list.length = writeIndex;
     this._update();
   }
 
@@ -1815,17 +1819,18 @@ export class URLSearchParams {
     name = toUSVString(name);
     value = toUSVString(value);
     let seen = false;
-    this._list = this._list.filter((pair) => {
+    let writeIndex = 0;
+    for (let readIndex = 0; readIndex < this._list.length; readIndex++) {
+      const pair = this._list[readIndex];
       if (pair[0] !== name) {
-        return true;
+        this._list[writeIndex++] = pair;
+      } else if (!seen) {
+        seen = true;
+        pair[1] = value;
+        this._list[writeIndex++] = pair;
       }
-      if (seen) {
-        return false;
-      }
-      seen = true;
-      pair[1] = value;
-      return true;
-    });
+    }
+    this._list.length = writeIndex;
     if (!seen) {
       this._list.push([name, value]);
     }

--- a/scripts/benchmark.js
+++ b/scripts/benchmark.js
@@ -165,6 +165,18 @@ const BENCHMARKS = {
     params.sort();
     return params.toString().length;
   },
+  'URLSearchParams repeated mutation': (URL, URLSearchParams) => {
+    const query = Array.from(
+      {length: 100},
+      (_, index) => `key${index}=${index}`,
+    ).join('&');
+    const params = new URLSearchParams(query);
+    return () => {
+      params.set('key50', 'updated');
+      params.delete('missing');
+      return params.size;
+    };
+  },
   'URL + searchParams roundtrip': (URL, URLSearchParams) => () => {
     const url = new URL('https://example.com/search?a=1&b=2&c=3');
     url.searchParams.append('d', '4');


### PR DESCRIPTION
## Summary

Replace the temporary arrays created by `URLSearchParams.set()` and `URLSearchParams.delete()` with in-place list compaction.

This avoids allocating and replacing the backing list on every mutation, particularly benefiting repeated operations on larger query parameter collections. It also preserves the existing live list rather than swapping its identity.

This work is separate from #499, which optimizes ASCII classification during URL parsing.

## Benchmark

Added a benchmark that repeatedly updates an existing key and deletes a missing key from a 100-entry `URLSearchParams` instance.

```text
50,000 iterations, median of 7

Before: 82.4 ms
After:  69.0 ms
Improvement: 16.3%
```

The optimization primarily targets larger, repeatedly mutated parameter lists. Existing small-list workloads remain effectively unchanged.

Run with:

```sh
yarn build
node scripts/benchmark.js 50000 7
```

## Specification compliance

- `set()` updates the first matching pair and removes subsequent matches.
- `set()` appends a pair when no matching name exists.
- `delete()` removes every pair matching the supplied name and optional value.
- Pair ordering is preserved.
- The list remains live for iterators and associated `URL` objects.

## Verification

- Full test suite: 1,692 passed
- Official Web Platform Tests: 28 passed
- Type checking passed
- Lint passed with only the existing `no-bitwise` warnings
- `git diff --check` passed