### PR TITLE
Optimize attached `URLSearchParams` appends

### DIFF
--- a/js/URL.ts
+++ b/js/URL.ts
@@ -1681,10 +1681,13 @@ export class URLSearchParams {
   _list: Array<[string, string]>;
   /** @internal */
   _urlObject: URL | null;
+  /** @internal */
+  _urlQueryIsSerialized: boolean;
 
   constructor(init?: URLSearchParamsInit | null) {
     this._list = [];
     this._urlObject = null;
+    this._urlQueryIsSerialized = false;
 
     if (init === undefined || init === null) {
       return;
@@ -1741,6 +1744,7 @@ export class URLSearchParams {
     const url = this._urlObject._url;
     const serialization = serializeUrlencoded(this._list);
     url.query = serialization === '' ? null : serialization;
+    this._urlQueryIsSerialized = true;
     if (serialization === '') {
       potentiallyStripTrailingSpacesFromOpaquePath(url);
     }
@@ -1752,8 +1756,23 @@ export class URLSearchParams {
 
   append(name: string, value: string): void {
     requireArguments('URLSearchParams.append', arguments.length, 2);
-    this._list.push([toUSVString(name), toUSVString(value)]);
-    this._update();
+    name = toUSVString(name);
+    value = toUSVString(value);
+    this._list.push([name, value]);
+    if (this._urlObject === null) {
+      return;
+    }
+    if (!this._urlQueryIsSerialized) {
+      this._update();
+      return;
+    }
+    const url = this._urlObject._url;
+    const serialization =
+      serializeUrlencodedComponent(name) +
+      '=' +
+      serializeUrlencodedComponent(value);
+    url.query =
+      url.query === null ? serialization : url.query + '&' + serialization;
   }
 
   delete(name: string, value?: string): void {
@@ -2017,6 +2036,7 @@ export class URL {
   _updateSearchParams(): void {
     if (this._searchParams !== null) {
       this._searchParams._list = parseUrlencoded(this._url.query || '');
+      this._searchParams._urlQueryIsSerialized = false;
     }
   }
 

--- a/js/__tests__/URL-test.js
+++ b/js/__tests__/URL-test.js
@@ -333,6 +333,22 @@ describe('URL — WPT URL.searchParams integration tests', () => {
     expect(url2.search).toBe('??a=b');
     expect(url2.searchParams.toString()).toBe('%3Fa=b');
   });
+
+  it('serializes existing parameters before incrementally appending', () => {
+    const url = new URL('https://example.org/?existing=~');
+    const searchParams = url.searchParams;
+
+    searchParams.append('first', 'one two');
+    searchParams.append('second', '~');
+
+    expect(url.search).toBe('?existing=%7E&first=one+two&second=%7E');
+
+    url.search = '?reset=~';
+    searchParams.append('after', 'reset');
+    searchParams.append('again', '~');
+
+    expect(url.search).toBe('?reset=%7E&after=reset&again=%7E');
+  });
 });
 
 // =============================================================================

--- a/scripts/benchmark.js
+++ b/scripts/benchmark.js
@@ -183,6 +183,13 @@ const BENCHMARKS = {
     url.searchParams.set('a', 'z');
     return url.href.length;
   },
+  'URL + searchParams repeated append': (URL, URLSearchParams) => () => {
+    const url = new URL('https://example.com/search');
+    for (let index = 0; index < 100; index++) {
+      url.searchParams.append(`key${index}`, `value${index}`);
+    }
+    return url.href.length;
+  },
 };
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Avoid serializing the complete parameter list after every consecutive `append()` to a `URL`-attached `URLSearchParams`.

The first append after a URL-side query change still performs full form serialization, preserving canonicalization of existing query bytes. Subsequent appends encode and concatenate only the new pair.

This is stacked on #502 so the PR contains only the append optimization.

## Benchmark

The benchmark builds a URL and appends 100 parameters through its live `searchParams` object.

```text
1,000 iterations, median of 15

Before: 645.7 ms (1.6% RSD)
After:   24.1 ms (4.2% RSD)
Improvement: 96.3% faster, approximately 26.8x
```

Run with:

```sh
yarn build
node scripts/benchmark.js 1000 15
```

## Correctness

- The first append canonicalizes pre-existing query parameters using form serialization.
- URL-side `search` and `href` changes invalidate the incremental append state.
- Empty queries and standalone `URLSearchParams` behavior remain unchanged.
- Added a regression test covering canonicalization and reset behavior.

## Verification

- Full test suite: 1,693 passed, 42 skipped
- Official Web Platform Tests: 28 passed
- Type checking passed
- Lint passed with only the six existing `no-bitwise` warnings
- `git diff --check` passed

## Size

- Build output: approximately +270 B uncompressed and +60 B gzip