### PR TITLE
Fix v4 package contents and declarations

### DIFF
--- a/js/__tests__/URL-test.js
+++ b/js/__tests__/URL-test.js
@@ -245,6 +245,29 @@ describe('URL — WPT setters tests (setters_tests.json)', () => {
   }
 });
 
+describe('URL — historical API tests', () => {
+  it('should reject a relative href assignment', () => {
+    const url = new URL('http://example.com/');
+
+    expect(() => {
+      url.href = './bar';
+    }).toThrow(TypeError);
+  });
+
+  it('should accept an absolute href assignment', () => {
+    const url = new URL('http://example.com/');
+
+    url.href = 'https://other.example/x';
+
+    expect(url.href).toBe('https://other.example/x');
+  });
+
+  it('should not expose Node-only domain conversion methods', () => {
+    expect(URL.domainToASCII).toBeUndefined();
+    expect(URL.domainToUnicode).toBeUndefined();
+  });
+});
+
 // =============================================================================
 // WPT URL.canParse() static method tests
 // =============================================================================

--- a/package.json
+++ b/package.json
@@ -24,8 +24,11 @@
     "index.js",
     "index.d.ts",
     "auto.js",
-    "js/*.js",
-    "js/*.d.ts"
+    "js/URL.js",
+    "js/URL.d.ts",
+    "js/URLSearchParams.js",
+    "js/URLSearchParams.d.ts",
+    "js/ios10Fix.js"
   ],
   "scripts": {
     "test": "jest",

--- a/tsdown.config.mjs
+++ b/tsdown.config.mjs
@@ -7,6 +7,7 @@ export default defineConfig({
   target: 'esnext',
   minify: true,
   dts: true,
+  tsconfig: 'tsconfig.build.json',
   outDir: 'js',
   clean: [
     'js/URL.js',


### PR DESCRIPTION
## Summary

Prepares `react-native-url-polyfill` v4.0.0 for publication by tightening package contents, removing internal members from generated declarations, and restoring missing historical API coverage.

## Changes

- Replace broad `js/*.js` and `js/*.d.ts` package globs with an explicit publish list.
- Exclude the WPT-only `js/url-conformance.js` harness from the npm tarball.
- Configure `tsdown` to use `tsconfig.build.json`, ensuring `stripInternal` removes internal fields and methods from `js/URL.d.ts`.
- Add regression tests confirming that relative `URL.href` assignments throw, absolute assignments still work, and Node-only domain conversion statics are not exposed.

No runtime implementation behavior was changed.

## Published Files

`npm pack --dry-run` includes:

```text
LICENSE
README.md
auto.js
index.d.ts
index.js
js/ios10Fix.js
js/URL.d.ts
js/URL.js
js/URLSearchParams.d.ts
js/URLSearchParams.js
package.json
```

`js/url-conformance.js` is no longer included.

## Verification

- `yarn test`: 6 suites passed, 1,699 passed, 42 skipped
- `yarn lint`: 0 errors, 6 existing `no-bitwise` warnings
- `yarn type-check`: passed
- `yarn build`: passed using `tsconfig.build.json`
- `npx tsc --noEmit --strict js/URL.d.ts`: passed
- Generated declarations contain no leaked internal members
- `npm pack --dry-run`: passed with the expected package contents