### PR TITLE
Add standalone Hermes benchmark runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,17 @@ const url = new URL('https://github.com');
 const searchParams = new URLSearchParams('q=GitHub');
 ```
 
+## Benchmarks
+
+Run the URL workloads on Node with `yarn benchmark [samples]`, or on the
+optimized standalone Hermes runtime bundled with React Native with
+`yarn benchmark:hermes [samples]`. The Hermes command currently relies on the
+standalone runtime shipped for supported host platforms (macOS in React Native
+0.81.4); `HERMES_BIN` and `HERMESC_BIN` can point to another matching binary pair.
+These desktop standalone-Hermes measurements are not representative of device
+performance. Unsupported optional implementations and operations are reported
+and skipped.
+
 ## License
 
 react-native-url-polyfill is [MIT licensed](LICENSE).

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "prepare": "husky install",
     "prepack": "yarn build",
     "benchmark": "yarn build && npx --yes --loglevel error --package whatwg-url --package whatwg-url-minimum -- sh -c 'NODE_PATH=\"${PATH%%/node_modules/.bin*}/node_modules\" node scripts/benchmark.js \"$@\"' sh",
+    "benchmark:hermes": "yarn build && npx --yes --loglevel error --package whatwg-url-without-unicode --package whatwg-url-minimum -- sh -c 'NODE_PATH=\"${PATH%%/node_modules/.bin*}/node_modules\" node scripts/benchmark-hermes.js \"$@\"' sh",
     "bundle-size": "node scripts/bundle-size",
     "update-wpt": "node scripts/update-wpt",
     "generate:wpt:react-native": "node scripts/wpt/generate-react-native-wpt.js"

--- a/scripts/benchmark-core.js
+++ b/scripts/benchmark-core.js
@@ -1,0 +1,259 @@
+/* eslint-disable no-bitwise -- XOR keeps benchmark results observable. */
+
+const DEFAULT_SAMPLES = 10;
+const WARMUP_ITERATIONS = 5000;
+const MAX_ACCEPTABLE_RSD = 5;
+const ITERATIONS_BY_BENCHMARK = {
+  'URL construction (absolute)': 5000,
+  'URL construction (relative + base)': 10000,
+  'URL.canParse (valid)': 5000,
+  'URL.canParse (invalid)': 100000,
+  'URL.parse': 5000,
+  'URL construction (percent-encoding)': 1500,
+  'URL property getters': 150000,
+  'URL setters': 30000,
+  'URLSearchParams parse': 20000,
+  'URLSearchParams percent-heavy stringify': 400,
+  'URLSearchParams manipulate + stringify': 50000,
+  'URLSearchParams repeated mutation': 500000,
+  'URL + searchParams roundtrip': 20000,
+  // Rebuilding the URL after each append is quadratic in the reference engines.
+  'URL + searchParams repeated append': 15,
+};
+
+const ABSOLUTE_URLS = [
+  'https://example.com/',
+  'http://user:pass@example.com:8080/path/to/resource?a=1&b=2&c=3#section',
+  'https://[2001:db8::1]:443/ipv6',
+  'ftp://192.168.0.1/file.txt',
+  'https://example.com/a/b/c/../../d/./e/f',
+  'mailto:someone@example.com',
+  'https://example.com/search?q=hello+world&lang=en-US&page=42',
+  'file:///C:/Users/test/file.txt',
+];
+
+const RELATIVE_URLS = [
+  ['../sibling', 'https://example.com/a/b/c'],
+  ['//other.com/path', 'https://example.com/'],
+  ['?newquery', 'https://example.com/page'],
+  ['#anchor', 'https://example.com/page?q=1'],
+  ['path/file', 'https://example.com/base/'],
+];
+
+const QUERIES = [
+  'a=1&b=2&c=3&d=4&e=5',
+  'name=John+Doe&email=john%40example.com&msg=Hello%2C+World%21',
+  'key=' + 'x'.repeat(200) + '&other=value',
+  'arr=1&arr=2&arr=3&arr=4&arr=5&arr=6',
+];
+
+/**
+ * Each benchmark is a factory `(URL, URLSearchParams) => () => number`. The outer
+ * call may allocate fixtures once; the returned function is what gets timed.
+ * Returning a value gives the timing loop something observable to consume so
+ * engines cannot prove the work is unused.
+ */
+const BENCHMARKS = {
+  'URL construction (absolute)': (URL) => () => {
+    let object = null;
+    for (const input of ABSOLUTE_URLS) {
+      object = new URL(input);
+    }
+    return object.protocol.length + object.pathname.length;
+  },
+  'URL construction (relative + base)': (URL) => () => {
+    let object = null;
+    for (const [input, base] of RELATIVE_URLS) {
+      object = new URL(input, base);
+    }
+    return object.protocol.length + object.pathname.length;
+  },
+  'URL.canParse (valid)': (URL) => () => {
+    let valid = false;
+    for (const input of ABSOLUTE_URLS) {
+      valid = URL.canParse(input);
+    }
+    return Number(valid);
+  },
+  'URL.canParse (invalid)': (URL) => () =>
+    Number(URL.canParse('https://[invalid-host/')),
+  'URL.parse': (URL) => () => {
+    let object = null;
+    for (const input of ABSOLUTE_URLS) {
+      object = URL.parse(input);
+    }
+    return object.href.length;
+  },
+  'URL construction (percent-encoding)': (URL) => {
+    const input = `https://example.com/${'路径 😀/'.repeat(100)}`;
+    return () => new URL(input).href.length;
+  },
+  'URL property getters': (URL) => {
+    const objects = ABSOLUTE_URLS.map((input) => new URL(input));
+    return () => {
+      let length = 0;
+      for (const object of objects) {
+        length += object.href.length;
+        length += object.protocol.length;
+        length += object.host.length;
+        length += object.hostname.length;
+        length += object.pathname.length;
+        length += object.search.length;
+        length += object.hash.length;
+        length += object.origin.length;
+      }
+      return length;
+    };
+  },
+  'URL setters': (URL) => {
+    const object = new URL('https://example.com/path?q=1');
+    return () => {
+      object.protocol = 'http:';
+      object.hostname = 'test.org';
+      object.port = '9090';
+      object.pathname = '/new/path';
+      object.search = '?a=1&b=2';
+      object.hash = '#top';
+      return object.href.length;
+    };
+  },
+  'URLSearchParams parse': (URL, URLSearchParams) => () => {
+    let params = null;
+    for (const query of QUERIES) {
+      params = new URLSearchParams(query);
+    }
+    return params.toString().length;
+  },
+  'URLSearchParams percent-heavy stringify': (URL, URLSearchParams) => {
+    const params = new URLSearchParams();
+    for (let index = 0; index < 100; index++) {
+      params.append(`键 ${index}`, '值 😀'.repeat(10));
+    }
+    return () => params.toString().length;
+  },
+  'URLSearchParams manipulate + stringify': (URL, URLSearchParams) => () => {
+    const params = new URLSearchParams('a=1&b=2&c=3');
+    params.append('d', '4');
+    params.set('a', 'updated');
+    params.delete('b');
+    params.sort();
+    return params.toString().length;
+  },
+  'URLSearchParams repeated mutation': (URL, URLSearchParams) => {
+    const query = Array.from(
+      {length: 100},
+      (_, index) => `key${index}=${index}`,
+    ).join('&');
+    const params = new URLSearchParams(query);
+    return () => {
+      params.set('key50', 'updated');
+      params.delete('missing');
+      return params.size;
+    };
+  },
+  'URL + searchParams roundtrip': (URL) => () => {
+    const url = new URL('https://example.com/search?a=1&b=2&c=3');
+    url.searchParams.append('d', '4');
+    url.searchParams.set('a', 'z');
+    return url.href.length;
+  },
+  'URL + searchParams repeated append': (URL) => () => {
+    const url = new URL('https://example.com/search');
+    for (let index = 0; index < 100; index++) {
+      url.searchParams.append(`key${index}`, `value${index}`);
+    }
+    return url.href.length;
+  },
+};
+
+function consume(value) {
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    return value.length;
+  }
+  return value == null ? 0 : String(value).length;
+}
+
+function timeit(fn, iterations, samples, now) {
+  const warmup = Math.min(iterations, WARMUP_ITERATIONS);
+  let sink = 0;
+  for (let i = 0; i < warmup; i++) {
+    sink ^= consume(fn());
+  }
+
+  const timings = [];
+  for (let run = 0; run < samples; run++) {
+    const start = now();
+    for (let i = 0; i < iterations; i++) {
+      sink ^= consume(fn());
+    }
+    timings.push(now() - start);
+  }
+  return {timings, sink};
+}
+
+function parseSamples(value) {
+  if (value === undefined) {
+    return DEFAULT_SAMPLES;
+  }
+  if (!/^\d+$/.test(value) || Number(value) < 1) {
+    throw new Error(
+      `Invalid sample count \`${value}\`; expected a positive integer.`,
+    );
+  }
+  return Number(value);
+}
+
+function median(values) {
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) {
+    return sorted[middle];
+  }
+  return (sorted[middle - 1] + sorted[middle]) / 2;
+}
+
+function stats(values) {
+  const mean = values.reduce((sum, value) => sum + value, 0) / values.length;
+  const variance =
+    values.reduce((sum, value) => sum + (value - mean) ** 2, 0) / values.length;
+  return {
+    median: median(values),
+    min: Math.min(...values),
+    max: Math.max(...values),
+    rsd: mean === 0 ? 0 : (Math.sqrt(variance) / mean) * 100,
+  };
+}
+
+function formatRatio(ms, baselineMs) {
+  if (ms === baselineMs) {
+    return 'baseline';
+  }
+  const ratio = ms / baselineMs;
+  if (ratio > 1) {
+    return `${ratio.toFixed(2)}x slower`;
+  }
+  return `${(1 / ratio).toFixed(2)}x faster`;
+}
+
+function formatStats(result, baselineMedian) {
+  const unstable = result.rsd > MAX_ACCEPTABLE_RSD ? ' !' : '';
+  return `${result.median.toFixed(1)} [${result.min.toFixed(
+    1,
+  )}-${result.max.toFixed(1)}, ${result.rsd.toFixed(1)}%] ${formatRatio(
+    result.median,
+    baselineMedian,
+  )}${unstable}`;
+}
+
+module.exports = {
+  BENCHMARKS,
+  ITERATIONS_BY_BENCHMARK,
+  MAX_ACCEPTABLE_RSD,
+  formatStats,
+  parseSamples,
+  stats,
+  timeit,
+};

--- a/scripts/benchmark-hermes-entry.js
+++ b/scripts/benchmark-hermes-entry.js
@@ -1,0 +1,103 @@
+/* eslint-disable no-bitwise -- UTF-8 decoding uses bit masks. */
+
+const {BENCHMARKS, timeit} = require('./benchmark-core');
+
+const RESULT_PREFIX = '__RN_URL_BENCHMARK_RESULT__';
+class TextEncoderShim {
+  encode(value = '') {
+    const bytes = [];
+    for (const character of String(value)) {
+      const point = character.codePointAt(0);
+      if (point <= 0x7f) {
+        bytes.push(point);
+      } else if (point <= 0x7ff) {
+        bytes.push(0xc0 | (point >> 6), 0x80 | (point & 0x3f));
+      } else if (point <= 0xffff) {
+        bytes.push(
+          0xe0 | (point >> 12),
+          0x80 | ((point >> 6) & 0x3f),
+          0x80 | (point & 0x3f),
+        );
+      } else {
+        bytes.push(
+          0xf0 | (point >> 18),
+          0x80 | ((point >> 12) & 0x3f),
+          0x80 | ((point >> 6) & 0x3f),
+          0x80 | (point & 0x3f),
+        );
+      }
+    }
+    return new Uint8Array(bytes);
+  }
+}
+
+class TextDecoderShim {
+  decode(input = new Uint8Array()) {
+    let output = '';
+    for (let index = 0; index < input.length; ) {
+      const first = input[index++];
+      let point;
+      if (first <= 0x7f) {
+        point = first;
+      } else if (first <= 0xdf) {
+        point = ((first & 0x1f) << 6) | (input[index++] & 0x3f);
+      } else if (first <= 0xef) {
+        point =
+          ((first & 0x0f) << 12) |
+          ((input[index++] & 0x3f) << 6) |
+          (input[index++] & 0x3f);
+      } else {
+        point =
+          ((first & 0x07) << 18) |
+          ((input[index++] & 0x3f) << 12) |
+          ((input[index++] & 0x3f) << 6) |
+          (input[index++] & 0x3f);
+      }
+      output += String.fromCodePoint(point);
+    }
+    return output;
+  }
+}
+
+function installHostShims() {
+  if (typeof globalThis.TextEncoder === 'undefined') {
+    globalThis.TextEncoder = TextEncoderShim;
+  }
+  if (typeof globalThis.TextDecoder === 'undefined') {
+    globalThis.TextDecoder = TextDecoderShim;
+  }
+}
+
+function runBenchmark(implementation, payload) {
+  const probe = 'https://user:pass@example.com:8080/a/b/../c?x=1&y=2#frag';
+  const expected = 'https://user:pass@example.com:8080/a/c?x=1&y=2#frag';
+  const actual = new implementation.URL(probe).href;
+  if (actual !== expected) {
+    throw new Error(`Sanity check failed: ${actual} !== ${expected}`);
+  }
+
+  if (payload.probe) {
+    const supportedBenchmarks = [];
+    for (const [label, factory] of Object.entries(BENCHMARKS)) {
+      try {
+        factory(implementation.URL, implementation.URLSearchParams)();
+        supportedBenchmarks.push(label);
+      } catch {
+        // Optional implementations may predate individual URL APIs.
+      }
+    }
+    globalThis.print(RESULT_PREFIX + JSON.stringify({supportedBenchmarks}));
+    return;
+  }
+
+  const factory = BENCHMARKS[payload.benchmark];
+  if (!factory) {
+    throw new Error(`Unknown benchmark: ${payload.benchmark}`);
+  }
+
+  const fn = factory(implementation.URL, implementation.URLSearchParams);
+  const result = timeit(fn, payload.iterations, payload.samples, Date.now);
+  globalThis.print(RESULT_PREFIX + JSON.stringify(result));
+}
+
+module.exports = {installHostShims, runBenchmark};

--- a/scripts/benchmark-hermes.js
+++ b/scripts/benchmark-hermes.js
@@ -1,0 +1,435 @@
+#!/usr/bin/node
+/* eslint-env node */
+
+/**
+ * Builds production Metro bundles and optimized bytecode for the standalone
+ * Hermes shell. These desktop measurements do not represent device performance.
+ *
+ * Usage: node scripts/benchmark-hermes.js [samples]
+ */
+
+const {spawnSync} = require('node:child_process');
+const {createRequire} = require('node:module');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const metro = require('metro');
+const {getDefaultConfig} = require('metro-config');
+const {
+  BENCHMARKS,
+  ITERATIONS_BY_BENCHMARK,
+  MAX_ACCEPTABLE_RSD,
+  formatStats,
+  parseSamples,
+  stats,
+} = require('./benchmark-core');
+
+const ROOT = path.resolve(__dirname, '..');
+const PACKAGE_JSON = require(path.join(ROOT, 'package.json'));
+const RESULT_PREFIX = '__RN_URL_BENCHMARK_RESULT__';
+const SDK_ROOT = path.join(ROOT, 'node_modules/react-native/sdks/hermesc');
+
+function executableName(name) {
+  return process.platform === 'win32' ? `${name}.exe` : name;
+}
+
+function isExecutable(file) {
+  try {
+    fs.accessSync(
+      file,
+      process.platform === 'win32' ? fs.constants.F_OK : fs.constants.X_OK,
+    );
+    return fs.statSync(file).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function discoverHermesBinaries() {
+  const environmentHermes = process.env.HERMES_BIN;
+  const environmentHermesc = process.env.HERMESC_BIN;
+  if (environmentHermes || environmentHermesc) {
+    if (
+      !environmentHermes ||
+      !environmentHermesc ||
+      !isExecutable(environmentHermes) ||
+      !isExecutable(environmentHermesc)
+    ) {
+      throw new Error(
+        '`HERMES_BIN` and `HERMESC_BIN` must both name executable files.',
+      );
+    }
+    return {hermes: environmentHermes, hermesc: environmentHermesc};
+  }
+
+  const preferredDirectory = {
+    darwin: 'osx-bin',
+    linux: 'linux64-bin',
+    win32: 'win64-bin',
+  }[process.platform];
+  const directories = [];
+  if (preferredDirectory) {
+    directories.push(path.join(SDK_ROOT, preferredDirectory));
+  }
+  const platformPattern = {
+    darwin: /(darwin|mac|osx)/i,
+    linux: /linux/i,
+    win32: /win/i,
+  }[process.platform];
+  if (platformPattern) {
+    try {
+      for (const entry of fs.readdirSync(SDK_ROOT, {withFileTypes: true})) {
+        const directory = path.join(SDK_ROOT, entry.name);
+        if (
+          entry.isDirectory() &&
+          platformPattern.test(entry.name) &&
+          !directories.includes(directory)
+        ) {
+          directories.push(directory);
+        }
+      }
+    } catch {
+      // The actionable error below covers a missing React Native SDK directory.
+    }
+  }
+
+  for (const directory of directories) {
+    const hermes = path.join(directory, executableName('hermes'));
+    const hermesc = path.join(directory, executableName('hermesc'));
+    if (isExecutable(hermes) && isExecutable(hermesc)) {
+      return {hermes, hermesc};
+    }
+  }
+
+  throw new Error(
+    `No standalone Hermes runtime/compiler pair was found for ${process.platform}/${process.arch} under ` +
+      `\`${SDK_ROOT}\`. React Native may only bundle \`hermesc\` on this platform. ` +
+      'Set `HERMES_BIN` and `HERMESC_BIN` to matching standalone binaries.',
+  );
+}
+
+function runCommand(command, args, description) {
+  const result = spawnSync(command, args, {encoding: 'utf8'});
+  if (result.error || result.status !== 0) {
+    const detail = result.error?.message || result.stderr || result.stdout;
+    throw new Error(
+      `${description} failed${detail ? `:\n${detail.trim()}` : ''}`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+function hermesVersion(hermes) {
+  for (const argument of ['-version', '--version']) {
+    const result = spawnSync(hermes, [argument], {encoding: 'utf8'});
+    if (!result.error && result.status === 0) {
+      return (result.stdout || result.stderr).trim();
+    }
+  }
+  return 'unknown version';
+}
+
+function nodeModulePaths() {
+  const paths = [path.join(ROOT, 'node_modules')];
+  if (process.env.NODE_PATH) {
+    paths.push(...process.env.NODE_PATH.split(path.delimiter).filter(Boolean));
+  }
+  return [...new Set(paths.map((entry) => path.resolve(entry)))];
+}
+
+function resolveOptionalPackage(packageName) {
+  const requireFromRoot = createRequire(path.join(ROOT, 'package.json'));
+  try {
+    return requireFromRoot.resolve(packageName, {paths: nodeModulePaths()});
+  } catch {
+    return null;
+  }
+}
+
+function optionalPackageVersion(packageName) {
+  const packagePath = resolveOptionalPackage(`${packageName}/package.json`);
+  return packagePath ? require(packagePath).version : 'unknown';
+}
+
+function loadEngines() {
+  const engines = [
+    {
+      label: 'react-native-url-polyfill',
+      name: 'react-native-url-polyfill',
+      version: PACKAGE_JSON.version,
+      modulePath: path.join(ROOT, 'js/URL.js'),
+      isBaseline: true,
+    },
+  ];
+  const notes = [];
+  for (const {name, label} of [
+    {
+      name: 'whatwg-url-without-unicode',
+      label: 'whatwg-url-without-unicode',
+    },
+    {name: 'whatwg-url-minimum', label: '(Expo) whatwg-url-minimum'},
+  ]) {
+    const modulePath = resolveOptionalPackage(name);
+    if (modulePath) {
+      engines.push({
+        label,
+        name,
+        version: optionalPackageVersion(name),
+        modulePath,
+      });
+    } else {
+      notes.push(
+        `\`${name}\` is unavailable. Run through \`yarn benchmark:hermes\` ` +
+          'to install optional competitors temporarily.',
+      );
+    }
+  }
+  return {engines, notes};
+}
+
+async function bundleEngine(engine, temporaryDirectory) {
+  const engineDirectory = path.join(
+    temporaryDirectory,
+    engine.name.replace(/[^a-z0-9-]/gi, '-'),
+  );
+  const stubDirectory = path.join(temporaryDirectory, 'react-native-stub');
+  fs.mkdirSync(engineDirectory, {recursive: true});
+  fs.mkdirSync(stubDirectory, {recursive: true});
+  fs.writeFileSync(
+    path.join(stubDirectory, 'package.json'),
+    JSON.stringify({name: 'react-native', main: 'index.js'}),
+  );
+  fs.writeFileSync(
+    path.join(stubDirectory, 'index.js'),
+    'module.exports = {NativeModules: {}};\n',
+  );
+
+  const entryPath = path.join(engineDirectory, 'entry.js');
+  const bundlePath = path.join(engineDirectory, 'benchmark.bundle.js');
+  const executableBundlePath = path.join(
+    engineDirectory,
+    'benchmark-executable.bundle.js',
+  );
+  const bytecodePath = path.join(engineDirectory, 'benchmark.hbc');
+  fs.writeFileSync(
+    entryPath,
+    "const runtime = require('benchmark-hermes-runtime');\n" +
+      'runtime.installHostShims();\n' +
+      "const implementation = require('benchmark-implementation');\n" +
+      'runtime.runBenchmark(implementation, globalThis.__RN_URL_BENCHMARK_PAYLOAD__);\n',
+  );
+
+  const modulePaths = nodeModulePaths();
+  const config = await getDefaultConfig(ROOT);
+  config.projectRoot = ROOT;
+  config.watchFolders = [ROOT, temporaryDirectory, ...modulePaths.slice(1)];
+  config.resolver.extraNodeModules = {'react-native': stubDirectory};
+  config.resolver.nodeModulesPaths = modulePaths;
+  config.resolver.resolveRequest = (context, moduleName, platform) => {
+    const aliases = {
+      'benchmark-hermes-runtime': path.join(
+        __dirname,
+        'benchmark-hermes-entry.js',
+      ),
+      'benchmark-implementation': engine.modulePath,
+      'react-native': path.join(stubDirectory, 'index.js'),
+    };
+    if (aliases[moduleName]) {
+      return {
+        filePath: aliases[moduleName],
+        type: 'sourceFile',
+      };
+    }
+    return context.resolveRequest(context, moduleName, platform);
+  };
+  config.resolver.useWatchman = false;
+  config.reporter = {update() {}};
+
+  const previousNodeEnvironment = process.env.NODE_ENV;
+  process.env.NODE_ENV = 'production';
+  try {
+    await metro.runBuild(config, {
+      bundleOut: bundlePath,
+      dev: false,
+      entry: entryPath,
+      minify: false,
+      platform: 'ios',
+      sourceMap: false,
+      unstable_transformProfile: 'hermes-stable',
+    });
+  } finally {
+    if (previousNodeEnvironment === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = previousNodeEnvironment;
+    }
+  }
+  return {bundlePath, bytecodePath, executableBundlePath};
+}
+
+function compileEngine(hermesc, paths, payload) {
+  fs.writeFileSync(
+    paths.executableBundlePath,
+    `globalThis.__RN_URL_BENCHMARK_PAYLOAD__ = ${JSON.stringify(payload)};\n` +
+      fs.readFileSync(paths.bundlePath, 'utf8'),
+  );
+  runCommand(
+    hermesc,
+    [
+      '-O',
+      '-emit-binary',
+      '-out',
+      paths.bytecodePath,
+      paths.executableBundlePath,
+    ],
+    'Hermes bytecode compilation',
+  );
+}
+
+function runInHermes(binaries, paths, payload) {
+  compileEngine(binaries.hermesc, paths, payload);
+  const output = runCommand(
+    binaries.hermes,
+    ['-b', paths.bytecodePath],
+    'Standalone Hermes execution',
+  );
+  const resultLine = output
+    .split(/\r?\n/)
+    .find((line) => line.startsWith(RESULT_PREFIX));
+  if (!resultLine) {
+    throw new Error(
+      `Standalone Hermes returned no benchmark result${output ? `:\n${output}` : ''}`,
+    );
+  }
+  return JSON.parse(resultLine.slice(RESULT_PREFIX.length));
+}
+
+async function prepareEngines(engines, binaries, temporaryDirectory, notes) {
+  const supported = [];
+  for (const engine of engines) {
+    try {
+      const paths = await bundleEngine(engine, temporaryDirectory);
+      const probe = runInHermes(binaries, paths, {probe: true});
+      const supportedBenchmarks = new Set(probe.supportedBenchmarks);
+      const unsupportedBenchmarks = Object.keys(BENCHMARKS).filter(
+        (label) => !supportedBenchmarks.has(label),
+      );
+      if (engine.isBaseline && unsupportedBenchmarks.length > 0) {
+        throw new Error(
+          `unsupported benchmark operations: ${unsupportedBenchmarks.join(', ')}`,
+        );
+      }
+      if (supportedBenchmarks.size === 0) {
+        throw new Error('no benchmark operations are supported');
+      }
+      if (unsupportedBenchmarks.length > 0) {
+        notes.push(
+          `\`${engine.name}\` does not implement these operations and reports n/a: ` +
+            unsupportedBenchmarks.join(', '),
+        );
+      }
+      supported.push({...engine, paths, supportedBenchmarks});
+    } catch (error) {
+      if (engine.isBaseline) {
+        throw new Error(`Unable to prepare ${engine.label}: ${error.message}`);
+      }
+      notes.push(`\`${engine.name}\` is unsupported: ${error.message}`);
+    }
+  }
+  return supported;
+}
+
+function printResults(engines, measurements, samples) {
+  console.log(
+    `\nStandalone Hermes benchmark: median-of-${samples}, fixed iterations per operation`,
+  );
+  console.log(
+    '(desktop standalone-Hermes measurements are not device performance; lower is faster)',
+  );
+  console.log(
+    '(each implementation/operation runs in an isolated Hermes process; ' +
+      'cells show median ms [min-max, relative standard deviation])\n',
+  );
+
+  const nameColumn = 54;
+  const numberColumn = 38;
+  let header = 'Operation (iterations)'.padEnd(nameColumn);
+  for (const engine of engines) {
+    header += `  ${`${engine.label}@${engine.version} (ms)`.padEnd(numberColumn)}`;
+  }
+  console.log(header);
+  console.log('-'.repeat(header.length));
+
+  for (const label of Object.keys(BENCHMARKS)) {
+    const iterations = ITERATIONS_BY_BENCHMARK[label];
+    let row = `${label} (${iterations.toLocaleString()})`.padEnd(nameColumn);
+    const results = engines.map((engine) => measurements[engine.name][label]);
+    for (const result of results) {
+      const cell = result ? formatStats(result, results[0].median) : 'n/a';
+      row += `  ${cell.padEnd(numberColumn)}`;
+    }
+    console.log(row);
+  }
+  console.log('-'.repeat(header.length));
+  console.log(`! indicates RSD above ${MAX_ACCEPTABLE_RSD}%.`);
+  console.log(
+    'Note: standalone Hermes exposes a millisecond clock, so very short rows may have coarse ranges.',
+  );
+}
+
+async function main() {
+  const samples = parseSamples(process.argv[2]);
+  const binaries = discoverHermesBinaries();
+  const version = hermesVersion(binaries.hermes);
+  console.log(`Standalone Hermes:\n${version}`);
+  console.log(`Samples: ${samples}`);
+
+  const temporaryDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'react-native-url-hermes-benchmark-'),
+  );
+  try {
+    const {engines, notes} = loadEngines();
+    const supported = await prepareEngines(
+      engines,
+      binaries,
+      temporaryDirectory,
+      notes,
+    );
+    const measurements = {};
+    for (const engine of supported) {
+      measurements[engine.name] = {};
+    }
+
+    let operationIndex = 0;
+    for (const label of Object.keys(BENCHMARKS)) {
+      const iterations = ITERATIONS_BY_BENCHMARK[label];
+      const offset = operationIndex % supported.length;
+      const orderedEngines = supported
+        .slice(offset)
+        .concat(supported.slice(0, offset))
+        .filter((engine) => engine.supportedBenchmarks.has(label));
+      for (const engine of orderedEngines) {
+        const measurement = runInHermes(binaries, engine.paths, {
+          benchmark: label,
+          iterations,
+          samples,
+        });
+        measurements[engine.name][label] = stats(measurement.timings);
+      }
+      operationIndex++;
+    }
+
+    printResults(supported, measurements, samples);
+    for (const note of notes) {
+      console.log(`\nNote: ${note}`);
+    }
+    console.log('');
+  } finally {
+    fs.rmSync(temporaryDirectory, {recursive: true, force: true});
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/scripts/benchmark.js
+++ b/scripts/benchmark.js
@@ -1,7 +1,5 @@
 #!/usr/bin/node
 /* eslint-env node */
-/* eslint-disable no-bitwise -- XOR keeps benchmark results observable. */
-
 /**
  * Micro-benchmark for the `URL` / `URLSearchParams` polyfill.
  *
@@ -26,27 +24,15 @@ const {createRequire} = require('node:module');
 const {spawnSync} = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
-
-const DEFAULT_SAMPLES = 10;
-const WARMUP_ITERATIONS = 5000;
-const MAX_ACCEPTABLE_RSD = 5;
-const ITERATIONS_BY_BENCHMARK = {
-  'URL construction (absolute)': 5000,
-  'URL construction (relative + base)': 10000,
-  'URL.canParse (valid)': 5000,
-  'URL.canParse (invalid)': 100000,
-  'URL.parse': 5000,
-  'URL construction (percent-encoding)': 1500,
-  'URL property getters': 150000,
-  'URL setters': 30000,
-  'URLSearchParams parse': 20000,
-  'URLSearchParams percent-heavy stringify': 400,
-  'URLSearchParams manipulate + stringify': 50000,
-  'URLSearchParams repeated mutation': 500000,
-  'URL + searchParams roundtrip': 20000,
-  // Rebuilding the URL after each append is quadratic in the reference engines.
-  'URL + searchParams repeated append': 15,
-};
+const {
+  BENCHMARKS,
+  ITERATIONS_BY_BENCHMARK,
+  MAX_ACCEPTABLE_RSD,
+  formatStats,
+  parseSamples,
+  stats,
+  timeit,
+} = require('./benchmark-core');
 
 // Loading `js/URL.ts` (an ES module in a package without `"type": "module"`)
 // triggers one-time notices from Node's module loader thread (module-syntax
@@ -87,189 +73,6 @@ const PACKAGE_JSON = require(path.join(ROOT, 'package.json'));
 const POLYFILL_PATH = fs.existsSync(path.join(ROOT, 'js/URL.js'))
   ? path.join(ROOT, 'js/URL.js')
   : path.join(ROOT, 'js/URL.ts');
-
-// -----------------------------------------------------------------------------
-// Workloads
-// -----------------------------------------------------------------------------
-
-const ABSOLUTE_URLS = [
-  'https://example.com/',
-  'http://user:pass@example.com:8080/path/to/resource?a=1&b=2&c=3#section',
-  'https://[2001:db8::1]:443/ipv6',
-  'ftp://192.168.0.1/file.txt',
-  'https://example.com/a/b/c/../../d/./e/f',
-  'mailto:someone@example.com',
-  'https://example.com/search?q=hello+world&lang=en-US&page=42',
-  'file:///C:/Users/test/file.txt',
-];
-
-const RELATIVE_URLS = [
-  ['../sibling', 'https://example.com/a/b/c'],
-  ['//other.com/path', 'https://example.com/'],
-  ['?newquery', 'https://example.com/page'],
-  ['#anchor', 'https://example.com/page?q=1'],
-  ['path/file', 'https://example.com/base/'],
-];
-
-const QUERIES = [
-  'a=1&b=2&c=3&d=4&e=5',
-  'name=John+Doe&email=john%40example.com&msg=Hello%2C+World%21',
-  'key=' + 'x'.repeat(200) + '&other=value',
-  'arr=1&arr=2&arr=3&arr=4&arr=5&arr=6',
-];
-
-/**
- * Each benchmark is a factory `(URL, URLSearchParams) => () => number`. The outer
- * call may allocate fixtures once; the returned function is what gets timed.
- * Returning a value gives the timing loop something observable to consume so
- * engines cannot prove the work is unused.
- */
-const BENCHMARKS = {
-  'URL construction (absolute)': (URL) => () => {
-    let object = null;
-    for (const input of ABSOLUTE_URLS) {
-      object = new URL(input);
-    }
-    return object.protocol.length + object.pathname.length;
-  },
-  'URL construction (relative + base)': (URL) => () => {
-    let object = null;
-    for (const [input, base] of RELATIVE_URLS) {
-      object = new URL(input, base);
-    }
-    return object.protocol.length + object.pathname.length;
-  },
-  'URL.canParse (valid)': (URL) => () => {
-    let valid = false;
-    for (const input of ABSOLUTE_URLS) {
-      valid = URL.canParse(input);
-    }
-    return Number(valid);
-  },
-  'URL.canParse (invalid)': (URL) => () =>
-    Number(URL.canParse('https://[invalid-host/')),
-  'URL.parse': (URL) => () => {
-    let object = null;
-    for (const input of ABSOLUTE_URLS) {
-      object = URL.parse(input);
-    }
-    return object.href.length;
-  },
-  'URL construction (percent-encoding)': (URL) => {
-    const input = `https://example.com/${'路径 😀/'.repeat(100)}`;
-    return () => new URL(input).href.length;
-  },
-  'URL property getters': (URL) => {
-    const objects = ABSOLUTE_URLS.map((input) => new URL(input));
-    return () => {
-      let length = 0;
-      for (const object of objects) {
-        length += object.href.length;
-        length += object.protocol.length;
-        length += object.host.length;
-        length += object.hostname.length;
-        length += object.pathname.length;
-        length += object.search.length;
-        length += object.hash.length;
-        length += object.origin.length;
-      }
-      return length;
-    };
-  },
-  'URL setters': (URL) => {
-    const object = new URL('https://example.com/path?q=1');
-    return () => {
-      object.protocol = 'http:';
-      object.hostname = 'test.org';
-      object.port = '9090';
-      object.pathname = '/new/path';
-      object.search = '?a=1&b=2';
-      object.hash = '#top';
-      return object.href.length;
-    };
-  },
-  'URLSearchParams parse': (URL, URLSearchParams) => () => {
-    let params = null;
-    for (const query of QUERIES) {
-      params = new URLSearchParams(query);
-    }
-    return params.toString().length;
-  },
-  'URLSearchParams percent-heavy stringify': (URL, URLSearchParams) => {
-    const params = new URLSearchParams();
-    for (let index = 0; index < 100; index++) {
-      params.append(`键 ${index}`, '值 😀'.repeat(10));
-    }
-    return () => params.toString().length;
-  },
-  'URLSearchParams manipulate + stringify': (URL, URLSearchParams) => () => {
-    const params = new URLSearchParams('a=1&b=2&c=3');
-    params.append('d', '4');
-    params.set('a', 'updated');
-    params.delete('b');
-    params.sort();
-    return params.toString().length;
-  },
-  'URLSearchParams repeated mutation': (URL, URLSearchParams) => {
-    const query = Array.from(
-      {length: 100},
-      (_, index) => `key${index}=${index}`,
-    ).join('&');
-    const params = new URLSearchParams(query);
-    return () => {
-      params.set('key50', 'updated');
-      params.delete('missing');
-      return params.size;
-    };
-  },
-  'URL + searchParams roundtrip': (URL, URLSearchParams) => () => {
-    const url = new URL('https://example.com/search?a=1&b=2&c=3');
-    url.searchParams.append('d', '4');
-    url.searchParams.set('a', 'z');
-    return url.href.length;
-  },
-  'URL + searchParams repeated append': (URL, URLSearchParams) => () => {
-    const url = new URL('https://example.com/search');
-    for (let index = 0; index < 100; index++) {
-      url.searchParams.append(`key${index}`, `value${index}`);
-    }
-    return url.href.length;
-  },
-};
-
-// -----------------------------------------------------------------------------
-// Timing
-// -----------------------------------------------------------------------------
-
-function consume(value) {
-  if (typeof value === 'number') {
-    return value;
-  }
-  if (typeof value === 'string') {
-    return value.length;
-  }
-  return value == null ? 0 : String(value).length;
-}
-
-function timeit(fn, iterations, samples) {
-  // Warmup so the JIT has settled before we measure.
-  const warmup = Math.min(iterations, WARMUP_ITERATIONS);
-  let sink = 0;
-  for (let i = 0; i < warmup; i++) {
-    sink ^= consume(fn());
-  }
-
-  const timings = [];
-  for (let run = 0; run < samples; run++) {
-    const start = process.hrtime.bigint();
-    for (let i = 0; i < iterations; i++) {
-      sink ^= consume(fn());
-    }
-    const elapsedMs = Number(process.hrtime.bigint() - start) / 1e6;
-    timings.push(elapsedMs);
-  }
-  return {timings, sink};
-}
 
 // -----------------------------------------------------------------------------
 // Engines under test
@@ -354,27 +157,6 @@ function loadOptionalPackage(require2, packageName) {
   return require2(resolved);
 }
 
-function median(values) {
-  const sorted = [...values].sort((a, b) => a - b);
-  const middle = Math.floor(sorted.length / 2);
-  if (sorted.length % 2 === 1) {
-    return sorted[middle];
-  }
-  return (sorted[middle - 1] + sorted[middle]) / 2;
-}
-
-function stats(values) {
-  const mean = values.reduce((sum, value) => sum + value, 0) / values.length;
-  const variance =
-    values.reduce((sum, value) => sum + (value - mean) ** 2, 0) / values.length;
-  return {
-    median: median(values),
-    min: Math.min(...values),
-    max: Math.max(...values),
-    rsd: mean === 0 ? 0 : (Math.sqrt(variance) / mean) * 100,
-  };
-}
-
 async function runWorker(payload) {
   const engines = await loadEngines({quiet: true});
   const engine = engines.find(
@@ -385,7 +167,12 @@ async function runWorker(payload) {
     throw new Error('Invalid benchmark worker payload');
   }
   const fn = factory(engine.URL, engine.URLSearchParams);
-  const result = timeit(fn, payload.iterations, payload.samples);
+  const result = timeit(
+    fn,
+    payload.iterations,
+    payload.samples,
+    () => Number(process.hrtime.bigint()) / 1e6,
+  );
   process.stdout.write(JSON.stringify(result));
 }
 
@@ -416,27 +203,6 @@ function runInWorker(engine, benchmark, iterations, samples) {
   return JSON.parse(result.stdout);
 }
 
-function formatRatio(ms, baselineMs) {
-  if (ms === baselineMs) {
-    return 'baseline';
-  }
-  const ratio = ms / baselineMs;
-  if (ratio > 1) {
-    return `${ratio.toFixed(2)}x slower`;
-  }
-  return `${(1 / ratio).toFixed(2)}x faster`;
-}
-
-function formatStats(result, baselineMedian) {
-  const unstable = result.rsd > MAX_ACCEPTABLE_RSD ? ' !' : '';
-  return `${result.median.toFixed(1)} [${result.min.toFixed(
-    1,
-  )}-${result.max.toFixed(1)}, ${result.rsd.toFixed(1)}%] ${formatRatio(
-    result.median,
-    baselineMedian,
-  )}${unstable}`;
-}
-
 // -----------------------------------------------------------------------------
 // Main
 // -----------------------------------------------------------------------------
@@ -447,7 +213,7 @@ async function main() {
     return;
   }
 
-  const samples = Number.parseInt(process.argv[2], 10) || DEFAULT_SAMPLES;
+  const samples = parseSamples(process.argv[2]);
   const engines = await loadEngines();
 
   // Sanity check: the polyfill must agree with the reference on a representative
@@ -537,4 +303,7 @@ async function main() {
   console.log('');
 }
 
-main();
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

- add `yarn benchmark:hermes [samples]` using the standalone Hermes runtime and compiler bundled with React Native 0.81.4
- share workloads, fixed iteration counts, timing statistics, and formatting with the Node benchmark
- build production Metro bundles and optimized HBC, then isolate each implementation and workload in a Hermes process
- compare against `whatwg-url-without-unicode` and `whatwg-url-minimum`, reporting unsupported operations as `n/a`
- discover host-matching binaries with `HERMES_BIN` and `HERMESC_BIN` overrides and clean all temporary artifacts
- document that standalone desktop results are not physical-device performance

React Native 0.81.4 is intentional because its macOS package includes a matching standalone `hermes` and `hermesc` pair. Newer React Native npm packages only provide the compiler.

## Validation

- `yarn benchmark:hermes 1`
- `yarn benchmark:hermes 5`
- `yarn benchmark 1`
- `yarn test --runInBand` (1,703 passed, 42 skipped)
- `yarn type-check`
- `yarn lint` (no errors; six existing `no-bitwise` warnings in `js/URL.ts`)
- Prettier check
- `git diff --check`

Confirmed React Native 0.81.4 Hermes with HBC bytecode version 96, successful execution of all supported competitor workloads, and temporary-directory cleanup after successful and induced-failure runs.